### PR TITLE
Update adverse events to display correct fields and meddra code

### DIFF
--- a/app/models/entities/AdverseEvent.scala
+++ b/app/models/entities/AdverseEvent.scala
@@ -4,13 +4,14 @@ import play.api.libs.json._
 import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 
-case class AdverseEvent(name: String, count: Long, logLR: Double, criticalValue: Double)
+case class AdverseEvent(name: String, meddraCode: Option[String], count: Long, logLR: Double, criticalValue: Double)
 
 case class AdverseEvents(count: Long, criticalValue: Double, rows: Seq[AdverseEvent])
 
 object AdverseEvent {
   implicit val AdverseEventImpReader: Reads[AdverseEvent] = (
-    (JsPath \ "chembl_id").read[String] and
+    (JsPath \ "event").read[String] and
+      (JsPath \ "meddraCode").readNullable[String] and
       (JsPath \ "count").read[Long] and
       (JsPath \ "llr").read[Double] and
       (JsPath \ "critval").read[Double]

--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -31,7 +31,7 @@ case class MechanismsOfAction(rows: Seq[MechanismOfActionRow],
                               uniqueTargetTypes: Seq[String])
 
 case class Drug(id: String,
-                name: Option[String],
+                name: String,
                 synonyms: Seq[String],
                 tradeNames: Seq[String],
                 yearOfFirstApproval: Option[Int],

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -333,6 +333,7 @@ object Objects extends Logging {
   implicit val adverseEventImp = deriveObjectType[Backend, AdverseEvent](
     ObjectTypeDescription("Significant adverse event entries"),
     DocumentField("name", "Meddra term on adverse event"),
+    DocumentField("meddraCode", "8 digit unique meddra identification number"),
     DocumentField("count", "Number of reports mentioning drug and adverse event"),
     DocumentField("logLR", "Log-likelihood ratio"),
     ExcludeFields("criticalValue")

--- a/production.conf
+++ b/production.conf
@@ -26,7 +26,7 @@ ot {
     apiVersion {
       x = 0
       y = 54
-      z = 6
+      z = 7
     }
     dataVersion {
       year = 20

--- a/production.conf
+++ b/production.conf
@@ -5,11 +5,6 @@ http.port = ${?PLAY_PORT}
 play.http.secret.key = "k:ax73XurOTlYSWyEkrLPx=P9HcpKLWprmBQi_]efV68ASNdiXd7a3lj?>M747f:"
 play.http.secret.key = ${?PLAY_SECRET}
 
-# env vars to pass to docker image or `-D`
-# http.port=${?PLAY_PORT}
-# play.http.secret.key=${?PLAY_SECRET}
-# slick.dbs.default.db.url=${?SLICK_CLICKHOUSE_URL}
-
 slick.dbs {
   default {
     profile = "clickhouse.ClickHouseProfile$"
@@ -22,9 +17,22 @@ slick.dbs {
     }
   }
 }
+ot {
+ elasticsearch {
+    host= "es7-20-11.c.open-targets-eu-dev.internal"
+ }
+ meta {
+    name = "Open Targets GraphQL & REST API Beta"
+    apiVersion {
+      x = 0
+      y = 54
+      z = 6
+    }
+    dataVersion {
+      year = 20
+      month = 11
+      iteration = 0
+    }
+  }
+}
 
-ot.elasticsearch.host = "es7-20-11.c.open-targets-eu-dev.internal"
-
-ot.elasticsearch.host=${?ELASTICSEARCH_HOST}
-ot.elasticsearch.port=${?ELASTICSEARCH_PORT}
-# slick.dbs.default.db.url=${?SLICK_CLICKHOUSE_URL_SS}


### PR DESCRIPTION
Resolves opentargets/platform#1295:
- Adverse events now show meddra name not ChEMBL id.
- New field on the GraphQL interface which includes Meddra code. 