### PR TITLE
Update drug index resolution of MoA and Indications

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -280,13 +280,23 @@ class Backend @Inject()(implicit ec: ExecutionContext, @NamedDatabase("default")
     val moaIndex = defaultESSettings.entities.find(_.name == "drugMoA").map(_.index)
 
     moaIndex match {
-      case Some(idx) => {
+      case Some(idx) =>
         esRetriever.getByIds(idx, ids, fromJsValue[MechanismsOfAction])
-      }
-      case None => {
+      case None =>
         logger.error("Unable to resolve mechanism of action elasticsearch index!")
         Future { IndexedSeq.empty }
-      }
+    }
+  }
+
+  def getIndications(ids: Seq[String]): Future[IndexedSeq[Indications]] = {
+    val index = defaultESSettings.entities.find(_.name == "drugIndications").map(_.index)
+
+    index match {
+      case Some(idx) =>
+        esRetriever.getByIds(idx, ids, fromJsValue[Indications])
+      case None =>
+        logger.error("Unable to resolve drug indications elasticsearch index!")
+        Future { IndexedSeq.empty }
     }
   }
 

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -325,6 +325,7 @@ class Backend @Inject()(implicit ec: ExecutionContext, @NamedDatabase("default")
   }
 
   def getIndications(ids: Seq[String]): Future[IndexedSeq[Indications]] = {
+    logger.debug(s"querying ES: getting indications for $ids")
     val index = defaultESSettings.entities.find(_.name == "drugIndications").map(_.index)
 
     index match {

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -41,7 +41,9 @@ object GQLSchema {
     expressionFetcher,
     mousePhenotypeFetcher,
     otarProjectsFetcher,
-    soTermsFetcher)
+    soTermsFetcher,
+    indicationFetcher
+  )
 
 
   lazy val msearchResultType = UnionType("EntityUnionType", types = List(targetImp, drugImp, diseaseImp))

--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -26,7 +26,8 @@ case class LinkedIds(count: Int, rows: Seq[String])
 
 case class Indications(rows: Seq[IndicationRow], count: Long)
 
-case class MechanismsOfAction(rows: Seq[MechanismOfActionRow],
+case class MechanismsOfAction(id: String,
+                              rows: Seq[MechanismOfActionRow],
                               uniqueActionTypes: Seq[String],
                               uniqueTargetTypes: Seq[String])
 
@@ -34,15 +35,16 @@ case class Drug(id: String,
                 name: String,
                 synonyms: Seq[String],
                 tradeNames: Seq[String],
+                childChemblIds: Option[Seq[String]],
                 yearOfFirstApproval: Option[Int],
                 drugType: String,
                 isApproved: Option[Boolean],
                 maximumClinicalTrialPhase: Option[Int],
                 hasBeenWithdrawn: Boolean,
                 withdrawnNotice: Option[WithdrawnNotice],
-                mechanismsOfAction: Option[MechanismsOfAction],
+                //mechanismsOfAction: Option[MechanismsOfAction],
                 approvedIndications: Option[Seq[String]],
-                indications: Option[Indications],
+                //indications: Option[Indications],
                 linkedDiseases: Option[LinkedIds],
                 linkedTargets: Option[LinkedIds],
                 blackBoxWarning: Boolean,

--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -1,7 +1,6 @@
 package models.entities
 
 import play.api.libs.json._
-import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 
 case class WithdrawnNotice(classes: Option[Seq[String]],
@@ -39,12 +38,11 @@ case class Drug(id: String,
                 yearOfFirstApproval: Option[Int],
                 drugType: String,
                 isApproved: Option[Boolean],
+                parentId: Option[String],
                 maximumClinicalTrialPhase: Option[Int],
                 hasBeenWithdrawn: Boolean,
                 withdrawnNotice: Option[WithdrawnNotice],
-                //mechanismsOfAction: Option[MechanismsOfAction],
                 approvedIndications: Option[Seq[String]],
-                //indications: Option[Indications],
                 linkedDiseases: Option[LinkedIds],
                 linkedTargets: Option[LinkedIds],
                 blackBoxWarning: Boolean,

--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -24,7 +24,7 @@ case class IndicationRow(maxPhaseForIndication: Long,
 
 case class LinkedIds(count: Int, rows: Seq[String])
 
-case class Indications(rows: Seq[IndicationRow], count: Long)
+case class Indications(id: String, indications: Seq[IndicationRow], count: Long)
 
 case class MechanismsOfAction(id: String,
                               rows: Seq[MechanismOfActionRow],

--- a/app/models/gql/Fetchers.scala
+++ b/app/models/gql/Fetchers.scala
@@ -2,7 +2,7 @@ package models.gql
 
 import models.Helpers.fromJsValue
 import models.{Backend, entities}
-import models.entities.{Disease, Drug, ECO, Expressions, MousePhenotypes, OtarProjects, Reactome, Target}
+import models.entities.{Disease, Drug, ECO, Expressions, MechanismsOfAction, MousePhenotypes, OtarProjects, Reactome, Target}
 import play.api.libs.json.JsValue
 import sangria.execution.deferred.{Fetcher, FetcherCache, FetcherConfig, HasId}
 
@@ -93,9 +93,18 @@ object Fetchers {
   implicit val drugHasId = HasId[Drug, String](_.id)
 
   val drugsFetcherCache = FetcherCache.simple
+
   val drugsFetcher = Fetcher(
     config = FetcherConfig.maxBatchSize(entities.Configuration.batchSize).caching(drugsFetcherCache),
     fetch = (ctx: Backend, ids: Seq[String]) => {
       ctx.getDrugs(ids)
     })
+
+  implicit val mechanismOfActionHasId = HasId[MechanismsOfAction, String](_.id)
+  val mechanismOfActionFetcher = Fetcher(
+    config = FetcherConfig.maxBatchSize(entities.Configuration.batchSize),
+    fetch = (ctx: Backend, ids: Seq[String]) => {
+      ctx.getMechanismsOfAction(ids)
+    })
+
 }

--- a/app/models/gql/Fetchers.scala
+++ b/app/models/gql/Fetchers.scala
@@ -2,7 +2,7 @@ package models.gql
 
 import models.Helpers.fromJsValue
 import models.{Backend, entities}
-import models.entities.{Disease, Drug, ECO, Expressions, MechanismsOfAction, MousePhenotypes, OtarProjects, Reactome, Target}
+import models.entities.{Disease, Drug, ECO, Expressions, Indications, MechanismsOfAction, MousePhenotypes, OtarProjects, Reactome, Target}
 import play.api.libs.json.JsValue
 import sangria.execution.deferred.{Fetcher, FetcherCache, FetcherConfig, HasId}
 
@@ -107,4 +107,10 @@ object Fetchers {
       ctx.getMechanismsOfAction(ids)
     })
 
+  implicit val indicationHasId = HasId[Indications, String](_.id)
+  val indicationFetcher = Fetcher(
+    config = FetcherConfig.maxBatchSize(entities.Configuration.batchSize),
+    fetch = (ctx: Backend, ids: Seq[String]) => {
+      ctx.getIndications(ids)
+    })
 }

--- a/app/models/gql/Fetchers.scala
+++ b/app/models/gql/Fetchers.scala
@@ -2,7 +2,7 @@ package models.gql
 
 import models.Helpers.fromJsValue
 import models.{Backend, entities}
-import models.entities.{Disease, Drug, ECO, Expressions, Indications, MechanismsOfAction, MousePhenotypes, OtarProjects, Reactome, Target}
+import models.entities.{Disease, Drug, ECO, Expressions, Indications, MousePhenotypes, OtarProjects, Reactome, Target}
 import play.api.libs.json.JsValue
 import sangria.execution.deferred.{Fetcher, FetcherCache, FetcherConfig, HasId}
 
@@ -98,13 +98,6 @@ object Fetchers {
     config = FetcherConfig.maxBatchSize(entities.Configuration.batchSize).caching(drugsFetcherCache),
     fetch = (ctx: Backend, ids: Seq[String]) => {
       ctx.getDrugs(ids)
-    })
-
-  implicit val mechanismOfActionHasId = HasId[MechanismsOfAction, String](_.id)
-  val mechanismOfActionFetcher = Fetcher(
-    config = FetcherConfig.maxBatchSize(entities.Configuration.batchSize),
-    fetch = (ctx: Backend, ids: Seq[String]) => {
-      ctx.getMechanismsOfAction(ids)
     })
 
   implicit val indicationHasId = HasId[Indications, String](_.id)

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -564,7 +564,7 @@ object Objects extends Logging {
           ctx.ctx.getIndications(ids) map { inds =>
             inds.size match {
               case i if i > 0 =>
-                logger.error(s"Received ${i} indications from ES")
+                logger.debug(s"Received ${i} indications from ES")
                 val indications = inds.flatMap(_.indications).map(r => r.disease -> r).toMap.values.toSeq
                 Some(Indications(inds.head.id,
                   indications,

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -542,21 +542,7 @@ object Objects extends Logging {
       Field("indications", OptionType(indicationsImp),
         description = Some("Investigational and approved indications curated from clinical trial records and " +
           "post-marketing package inserts"),
-        resolve = ctx => {
-          val ids: Seq[String] = Seq(ctx.value.id) ++ ctx.value.childChemblIds.getOrElse(Seq.empty)
-          ctx.ctx.getIndications(ids) map { inds =>
-            inds.size match {
-              case i if i > 0 =>
-                logger.debug(s"Received ${i} indications from ES")
-                val indications = inds.flatMap(_.indications).map(r => r.disease -> r).toMap.values.toSeq
-                Some(Indications(inds.head.id,
-                  indications,
-                  indications.size
-                ))
-              case _ => inds.headOption
-            }
-          }
-        }
+        resolve = ctx => DeferredValue(indicationFetcher.defer(ctx.value.id))
       ),
       Field("knownDrugs", OptionType(knownDrugsImp),
         description = Some("Curated Clinical trial records and and post-marketing package inserts " +

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1,35 +1,18 @@
 package models.gql
 
 import models._
-import models.entities._
-import models.entities.Interactions._
 import models.entities.Configuration._
+import models.entities.Evidences._
+import models.entities.Interactions._
+import models.entities._
+import models.gql.Arguments._
+import models.gql.Fetchers._
 import play.api.Logging
 import sangria.macros.derive._
 import sangria.schema._
-import sangria.marshalling.playJson._
-import sangria.schema.AstSchemaBuilder._
-import play.api.libs.json.{JsValue, Json}
-import play.api.Logging
-import sangria.schema._
-import sangria.macros.{derive, _}
-import sangria.macros.derive._
-import sangria.ast
-import sangria.execution._
-import sangria.marshalling.playJson._
-import sangria.schema.AstSchemaBuilder._
-import sangria.util._
-import play.api.Configuration
-import play.api.mvc.CookieBaker
-import sangria.execution.deferred._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
-import Arguments._
-import Fetchers._
-import play.api.libs.json.JsValue.jsValueToJsLookup
-import models.entities.Evidence._
-import models.entities.Evidences._
 
 object Objects extends Logging {
   implicit val metaDataVersionImp = deriveObjectType[Backend, DataVersion]()

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -612,7 +612,7 @@ object Objects extends Logging {
       resolve = r => r.value.linkedDiseases)),
     ReplaceField("linkedTargets", Field("linkedTargets", OptionType(linkedTargetsImp),
       Some("Molecule targets based on drug mechanism of action"),
-      resolve = r => r.value.linkedTargets))
+      resolve = ctx => ctx.ctx.getLinkedTargets(ctx.value)))
   )
 
   implicit val datasourceSettingsImp = deriveObjectType[Backend, DatasourceSettings]()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -125,6 +125,10 @@ ot {
       {
         name = "drugMoA"
         index = "mechanism_of_action"
+      },
+      {
+        name = "drugIndications"
+        index = "indication"
       }
     ]
     highlightFields = [

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -121,6 +121,10 @@ ot {
         name = "drug"
         index = "drug"
         searchIndex = "search_drug"
+      },
+      {
+        name = "drugMoA"
+        index = "mechanism_of_action"
       }
     ]
     highlightFields = [

--- a/test/controllers/GraphQLControllerTest.scala
+++ b/test/controllers/GraphQLControllerTest.scala
@@ -78,6 +78,16 @@ class GraphQLControllerTest extends PlaySpec with GuiceOneAppPerTest with Inject
       parentDiseases should contain.allElementsOf(childDiseases)
       childDiseases should contain.allElementsOf(parentDiseases)
     }
+    "consolidate linked targets from parent to child" taggedAs IntegrationTestTag in {
+      val r = request.withBody(parentChildLinkedTargetQuery)
+      val jsObject = Json.parse(contentAsString(controller.gqlBody.apply(r)))
+      val drugs = (jsObject \ "data" \ "drugs").as[JsArray].value.map(_.as[ParentChildLinkedTargets])
+      val (d1,d2) = (drugs.head, drugs.tail.head)
+      forAll(drugs)(d =>
+        assert(d.linkedTargets.isDefined)
+      )
+      d1.linkedTargets.get.count should equal(d2.linkedTargets.get.count)
+    }
   }
 
   "Adverse event queries" must {

--- a/test/controllers/GraphQLControllerTest.scala
+++ b/test/controllers/GraphQLControllerTest.scala
@@ -6,10 +6,11 @@ import akka.util.Timeout
 import controllers.api.v4.graphql.GraphQLController
 import inputs.{AdverseEventInputs, DrugInputs}
 import org.scalatest.Inspectors.forAll
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import play.api.Logging
-import play.api.libs.json.Json
+import play.api.libs.json.{JsArray, Json}
 import play.api.test.Helpers.{POST, contentAsString}
 import play.api.test.{FakeRequest, Injecting}
 import test_configuration.IntegrationTestTag
@@ -21,60 +22,83 @@ class GraphQLControllerTest extends PlaySpec with GuiceOneAppPerTest with Inject
 
   "Drug queries" must {
     "return an id " taggedAs IntegrationTestTag in {
-      val responses: Seq[String] = chemblIds.map(idQuery).map{ q => {
+      val responses: Seq[String] = chemblIds.map(idQuery).map { q => {
         val request = FakeRequest(POST, "/graphql")
           .withHeaders(("Content-Type", "application/json"))
           .withBody(q)
         contentAsString(controller.gqlBody.apply(request))
-      }}
+      }
+      }
       val results = responses.zip(chemblIds).filter(s => s._1.contains("errors"))
       logger.info(s"${responses.size - results.size} entries had no errors.")
       logger.info(s"${results.size} entries contained errors.")
       results.foreach(e => logger.info(s"ID: ${e._2} \t Error: ${e._1}"))
 
-      forAll (responses){ r =>
+      forAll(responses) { r =>
         r must include("data")
         r mustNot include("errors")
       }
     }
     "return full objects" taggedAs IntegrationTestTag in {
-      val responses: Seq[String] = chemblIds.map(fullQuery).map{ q => {
+      val responses: Seq[String] = chemblIds.map(fullQuery).map { q => {
         val request = FakeRequest(POST, "/graphql")
           .withHeaders(("Content-Type", "application/json"))
           .withBody(q)
         contentAsString(controller.gqlBody.apply(request))
-      }}
+      }
+      }
       val results = responses.zip(chemblIds).filter(s => s._1.contains("errors"))
       logger.info(s"${responses.size - results.size} entries had no errors.")
       logger.info(s"${results.size} entries contained errors.")
       results.foreach(e => logger.info(s"ID: ${e._2} \t Error: ${e._1}"))
 
-      forAll (responses){ r =>
+      forAll(responses) { r =>
         r must include("data")
         r mustNot include("errors")
       }
     }
+  }
 
+  "Hierarchical drug queries" must {
+    lazy val request = FakeRequest(POST, "/graphql")
+      .withHeaders(("Content-Type", "application/json"))
+      .withBody(parentChildMoAQuery)
+    lazy val jsObject = Json.parse(contentAsString(controller.gqlBody.apply(request)))
+    lazy val drugs: Seq[ParentChildMoAReturn] = (jsObject \ "data" \ "drugs").as[JsArray].value.map(_.as[ParentChildMoAReturn])
+    lazy val (parent, child) = (drugs.head, drugs.tail.head)
+
+    "pass their children's mechanisms of action to their parents" taggedAs IntegrationTestTag in {
+      assert(parent.mechanismsOfAction.get.uniqueTargetTypes sameElements child.mechanismsOfAction.get.uniqueTargetTypes)
+      assert(parent.mechanismsOfAction.get.uniqueActionTypes sameElements child.mechanismsOfAction.get.uniqueActionTypes)
+      assert(parent.mechanismsOfAction.get.rows.length == child.mechanismsOfAction.get.rows.length)
+    }
+    "pass their children's indications to their parents" taggedAs IntegrationTestTag in {
+      val childDiseases = child.indications.get.rows.map(_.disease.id)
+      val parentDiseases = parent.indications.get.rows.map(_.disease.id)
+      parentDiseases should contain.allElementsOf(childDiseases)
+      childDiseases should contain.allElementsOf(parentDiseases)
+    }
   }
 
   "Adverse event queries" must {
     "return valid objects when an adverse event is associated with the id" taggedAs IntegrationTestTag in {
-      val responses: Seq[String] = aeChemblIds.map(simpleAeQuery).map{ q => {
+      val responses: Seq[String] = aeChemblIds.map(simpleAeQuery).map { q => {
         val request = FakeRequest(POST, "/graphql")
           .withHeaders(("Content-Type", "application/json"))
           .withBody(q)
         contentAsString(controller.gqlBody.apply(request))
-      }}
+      }
+      }
       val results = responses.zip(chemblIds).filter(s => s._1.contains("errors"))
       logger.info(s"${responses.size - results.size} entries had no errors.")
       logger.info(s"${results.size} entries contained errors.")
       results.foreach(e => logger.info(s"ID: ${e._2} \t Error: ${e._1}"))
 
-      forAll (responses){ r =>
+      forAll(responses) { r =>
         r must include("data")
         r mustNot include("errors")
         val jsonResponse = Json.parse(responses.head)
-        assert((jsonResponse \ "data" \ "drug" \"adverseEvents").isDefined)
+        assert((jsonResponse \ "data" \ "drug" \ "adverseEvents").isDefined)
       }
 
     }

--- a/test/controllers/GraphQLControllerTest.scala
+++ b/test/controllers/GraphQLControllerTest.scala
@@ -40,10 +40,14 @@ class GraphQLControllerTest extends PlaySpec with GuiceOneAppPerTest with Inject
       }
     }
     "return full objects" taggedAs IntegrationTestTag in {
+      val tests = chemblIds.length
+      var i = 1
       val responses: Seq[String] = chemblIds.map(fullQuery).map { q => {
         val request = FakeRequest(POST, "/graphql")
           .withHeaders(("Content-Type", "application/json"))
           .withBody(q)
+        logger.info(s"Test $i of $tests")
+        i = i + 1
         contentAsString(controller.gqlBody.apply(request))
       }
       }

--- a/test/controllers/GraphQLControllerTest.scala
+++ b/test/controllers/GraphQLControllerTest.scala
@@ -75,8 +75,7 @@ class GraphQLControllerTest extends PlaySpec with GuiceOneAppPerTest with Inject
     "pass their children's indications to their parents" taggedAs IntegrationTestTag in {
       val childDiseases = child.indications.get.rows.map(_.disease.id)
       val parentDiseases = parent.indications.get.rows.map(_.disease.id)
-      parentDiseases should contain.allElementsOf(childDiseases)
-      childDiseases should contain.allElementsOf(parentDiseases)
+      parentDiseases should contain allElementsOf childDiseases
     }
     "consolidate linked targets from parent to child" taggedAs IntegrationTestTag in {
       val r = request.withBody(parentChildLinkedTargetQuery)

--- a/test/inputs/DrugInputs.scala
+++ b/test/inputs/DrugInputs.scala
@@ -1,6 +1,6 @@
 package inputs
 
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsValue, Json, Reads}
 
 trait DrugInputs {
   lazy val chemblIds: Seq[String] = Seq(
@@ -1189,5 +1189,21 @@ trait DrugInputs {
       + """linkedDiseases {count rows { id name description } }"""
       + """} }" }"""
   )
+
+  val parentChildMoAQuery: JsValue = Json.parse(
+    """{"query": "query { drugs(chemblIds: [\"CHEMBL221959\", \"CHEMBL2103743\"]) { name mechanismsOfAction { uniqueActionTypes uniqueTargetTypes rows { targetName targets {id} } } indications { count rows { disease { id } } } } }" }"""
+  )
+  case class IDS(id: String)
+  case class MOAR(targetName: String, targets: Array[IDS])
+  case class MOA(uniqueActionTypes: Array[String], uniqueTargetTypes: Array[String], rows: Array[MOAR])
+  case class IndRow(disease: IDS)
+  case class IndicationT(count: Int, rows: Array[IndRow])
+  case class ParentChildMoAReturn(name: String, mechanismsOfAction: Option[MOA], indications: Option[IndicationT])
+  implicit val idsReads: Reads[IDS] = Json.reads[IDS]
+  implicit val moarReads: Reads[MOAR] = Json.reads[MOAR]
+  implicit val moaReads: Reads[MOA] = Json.reads[MOA]
+  implicit val indRowReads: Reads[IndRow] = Json.reads[IndRow]
+  implicit val indReads: Reads[IndicationT] = Json.reads[IndicationT]
+  implicit val trReads: Reads[ParentChildMoAReturn] = Json.reads[ParentChildMoAReturn]
 }
 

--- a/test/inputs/DrugInputs.scala
+++ b/test/inputs/DrugInputs.scala
@@ -1193,17 +1193,26 @@ trait DrugInputs {
   val parentChildMoAQuery: JsValue = Json.parse(
     """{"query": "query { drugs(chemblIds: [\"CHEMBL221959\", \"CHEMBL2103743\"]) { name mechanismsOfAction { uniqueActionTypes uniqueTargetTypes rows { targetName targets {id} } } indications { count rows { disease { id } } } } }" }"""
   )
+  val parentChildLinkedTargetQuery: JsValue = Json.parse(
+     """{"query": "query { drugs(chemblIds: [\"CHEMBL221959\", \"CHEMBL2103743\"]) { name linkedTargets { count rows { approvedSymbol } } } }" }"""
+  )
   case class IDS(id: String)
   case class MOAR(targetName: String, targets: Array[IDS])
   case class MOA(uniqueActionTypes: Array[String], uniqueTargetTypes: Array[String], rows: Array[MOAR])
   case class IndRow(disease: IDS)
   case class IndicationT(count: Int, rows: Array[IndRow])
+  case class LtRow(approvedSymbol: String)
+  case class LinkedTargets(count: Int, rows: Array[LtRow])
   case class ParentChildMoAReturn(name: String, mechanismsOfAction: Option[MOA], indications: Option[IndicationT])
+  case class ParentChildLinkedTargets(name: String, linkedTargets: Option[LinkedTargets])
   implicit val idsReads: Reads[IDS] = Json.reads[IDS]
   implicit val moarReads: Reads[MOAR] = Json.reads[MOAR]
   implicit val moaReads: Reads[MOA] = Json.reads[MOA]
   implicit val indRowReads: Reads[IndRow] = Json.reads[IndRow]
   implicit val indReads: Reads[IndicationT] = Json.reads[IndicationT]
+  implicit val ltRowReads: Reads[LtRow] = Json.reads[LtRow]
+  implicit val linkedTargetReads: Reads[LinkedTargets] = Json.reads[LinkedTargets]
+  implicit val pcLinkedTargets: Reads[ParentChildLinkedTargets] = Json.reads[ParentChildLinkedTargets]
   implicit val trReads: Reads[ParentChildMoAReturn] = Json.reads[ParentChildMoAReturn]
 }
 

--- a/test/inputs/DrugInputs.scala
+++ b/test/inputs/DrugInputs.scala
@@ -1190,11 +1190,11 @@ trait DrugInputs {
       + """} }" }"""
   )
 
-  val parentChildMoAQuery: JsValue = Json.parse(
-    """{"query": "query { drugs(chemblIds: [\"CHEMBL221959\", \"CHEMBL2103743\"]) { name mechanismsOfAction { uniqueActionTypes uniqueTargetTypes rows { targetName targets {id} } } indications { count rows { disease { id } } } } }" }"""
+  def parentChildMoAQuery(parent: String, child: String): JsValue = Json.parse(
+    s"""{"query": "query { drugs(chemblIds: [\\"$parent\\", \\"$child\\"]) { name mechanismsOfAction { uniqueActionTypes uniqueTargetTypes rows { targetName targets {id} } } indications { count rows { disease { id } } } } }" }"""
   )
-  val parentChildLinkedTargetQuery: JsValue = Json.parse(
-     """{"query": "query { drugs(chemblIds: [\"CHEMBL221959\", \"CHEMBL2103743\"]) { name linkedTargets { count rows { approvedSymbol } } } }" }"""
+  def parentChildLinkedTargetQuery(parent: String, child: String): JsValue = Json.parse(
+     s"""{"query": "query { drugs(chemblIds: [\\"$parent\\", \\"$child\\"]) { name linkedTargets { count rows { approvedSymbol } } } }" }"""
   )
   case class IDS(id: String)
   case class MOAR(targetName: String, targets: Array[IDS])


### PR DESCRIPTION
Updated GraphQL resolving logic to meet specification in ticket opentargets/platform#1308

- Indications are not inherited in either direction
- MoA are treated as a family of molecules, so parent, child and sibling all have the same MoAs and Linked Targets
- Add and expose parentId to model
- Expose childIds