### PR TITLE
1590 parent child indication

### DIFF
--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -28,7 +28,7 @@ case class IndicationRow(maxPhaseForIndication: Long,
 
 case class LinkedIds(count: Int, rows: Seq[String])
 
-case class Indications(id: String, indications: Seq[IndicationRow], count: Long)
+case class Indications(id: String, indications: Seq[IndicationRow], indicationCount: Long, approvedIndications: Option[Seq[String]])
 
 case class MechanismsOfAction(rows: Seq[MechanismOfActionRow],
                               uniqueActionTypes: Seq[String],
@@ -55,7 +55,6 @@ case class Drug(id: String,
                 parentId: Option[String],
                 maximumClinicalTrialPhase: Option[Int],
                 hasBeenWithdrawn: Boolean,
-                approvedIndications: Option[Seq[String]],
                 linkedDiseases: Option[LinkedIds],
                 linkedTargets: Option[LinkedIds],
                 blackBoxWarning: Boolean,

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -729,13 +729,8 @@ object Objects extends Logging {
         "approvedIndications",
         OptionType(ListType(StringType)),
         description = Some("Indications for which there is a phase IV clinical trial"),
-        resolve = c => {
-          val indications = DeferredValue(indicationFetcher.deferOpt(c.value.id))
-          indications.map {
-            case Some(value) => value.approvedIndications
-            case None => Some(Seq.empty)
-          }
-        }
+        resolve = r => DeferredValue(indicationFetcher.deferOpt(r.value.id))
+          .map(_.get.approvedIndications)
       ),
       Field(
         "drugWarnings",

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -730,8 +730,11 @@ object Objects extends Logging {
         OptionType(ListType(StringType)),
         description = Some("Indications for which there is a phase IV clinical trial"),
         resolve = c => {
-          val indications = DeferredValue(indicationFetcher.defer(c.value.id))
-          indications.map(inds => inds.approvedIndications)
+          val indications = DeferredValue(indicationFetcher.deferOpt(c.value.id))
+          indications.map {
+            case Some(value) => value.approvedIndications
+            case None => Some(Seq.empty)
+          }
         }
       ),
       Field(

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -674,7 +674,8 @@ object Objects extends Logging {
 
   implicit lazy val indicationsImp = deriveObjectType[Backend, Indications](
     ExcludeFields("id"),
-    RenameField("indications", "rows")
+    RenameField("indications", "rows"),
+    RenameField("indicationCount", "count"),
   )
 
   implicit lazy val mechanismOfActionImp = deriveObjectType[Backend, MechanismsOfAction]()
@@ -705,8 +706,6 @@ object Objects extends Logging {
                     " post-marketing package inserts"),
     DocumentField("isApproved", "Alias for maximumClinicalTrialPhase == 4"),
     DocumentField("hasBeenWithdrawn", "Has drug been withdrawn from the market"),
-    DocumentField("approvedIndications",
-                  "Indications for which there is a phase IV clinical trial"),
     DocumentField("blackBoxWarning", "Alert on life-threteaning drug side effects provided by FDA"),
     DocumentField("description", "Drug description"),
     ReplaceField(
@@ -726,6 +725,15 @@ object Objects extends Logging {
       )
     ),
     AddFields(
+      Field(
+        "approvedIndications",
+        OptionType(ListType(StringType)),
+        description = Some("Indications for which there is a phase IV clinical trial"),
+        resolve = c => {
+          val indications = DeferredValue(indicationFetcher.defer(c.value.id))
+          indications.map(inds => inds.approvedIndications)
+        }
+      ),
       Field(
         "drugWarnings",
         ListType(drugWarningsImp),

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -730,7 +730,7 @@ object Objects extends Logging {
         OptionType(ListType(StringType)),
         description = Some("Indications for which there is a phase IV clinical trial"),
         resolve = r => DeferredValue(indicationFetcher.deferOpt(r.value.id))
-          .map(_.get.approvedIndications)
+          .map(_.flatMap(_.approvedIndications))
       ),
       Field(
         "drugWarnings",

--- a/test/inputs/GqlItTestInputs.scala
+++ b/test/inputs/GqlItTestInputs.scala
@@ -9,7 +9,7 @@ trait GqlItTestInputs {
 
   lazy val geneInputs = File(this.getClass.getResource(s"/gqlInputs/genes.txt").getPath).lines.toList
   lazy val diseaseInputs = File(this.getClass.getResource(s"/gqlInputs/efos.txt").getPath).lines.toList
-  lazy val drugInputs = Seq("CHEMBL1430")
+  lazy val drugInputs = File(this.getClass.getResource(s"/gqlInputs/drugs.txt").getPath).lines.toList
 
   val aggregationFilterMap: Map[String, Seq[String]] = Map(
     "pathwayTypes" -> Seq(


### PR DESCRIPTION
- Updated `approvedIndication` to come from the Indication index rather than Drug (where it no longer exists). 
- Fixed test inputs so proper static file is used for input generation. 
