### PR TITLE
Update gql tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,14 +100,14 @@ updateGqlFiles := {
     .filter(_.contains((Test / resourceDirectory).value.getName))
 
   val newFiles = gitStatusOpt("u")
+  val updatedFiles = gitStatusOpt("uno")
+
   if (newFiles.nonEmpty) {
     println("New files found:")
-    newFiles.foreach(println)
+    newFiles.filterNot(f => updatedFiles.contains(f)).foreach(println)
   } else {
     println("No new files found since last update.")
   }
-
-  val updatedFiles = gitStatusOpt("uno")
 
   if (updatedFiles.nonEmpty) {
     println("Files updated since last refresh:")
@@ -115,7 +115,6 @@ updateGqlFiles := {
   } else {
     println("No existing files have been updated since last check.")
   }
-
 
 }
 

--- a/test/controllers/GqlTest.scala
+++ b/test/controllers/GqlTest.scala
@@ -198,7 +198,9 @@ class GqlTest
     }
     "return a valid response for Open Targets Genetics summary fragments" taggedAs IntegrationTestTag in {
       testQueryAgainstGqlEndpoint(DiseaseSummaryFragment("OTGenetics_OpenTargetsGeneticsSummary"))
-
+    }
+    "return a valid response for orphanet summary fragment" taggedAs IntegrationTestTag in {
+      testQueryAgainstGqlEndpoint(DiseaseSummaryFragment("Orphanet_OrphanetSummaryFragment"))
     }
     "return a valid response for Phenodigm summary fragments" taggedAs IntegrationTestTag in {
       testQueryAgainstGqlEndpoint(DiseaseSummaryFragment("Phenodigm_PhenodigmSummaryFragment"))
@@ -364,6 +366,12 @@ class GqlTest
   "OT genetics queries" must {
     "return valid responses" taggedAs IntegrationTestTag in {
       testQueryAgainstGqlEndpoint(TargetDiseaseSize("OTGenetics_sectionQuery"))
+    }
+  }
+
+  "Orphanet queries" must {
+    "return valid responses" taggedAs IntegrationTestTag in {
+      testQueryAgainstGqlEndpoint(TargetDiseaseSize("Orphanet_OrphanetQuery"))
     }
   }
 

--- a/test/controllers/GqlTest.scala
+++ b/test/controllers/GqlTest.scala
@@ -199,6 +199,9 @@ class GqlTest
     "return a valid response for Open Targets Genetics summary fragments" taggedAs IntegrationTestTag in {
       testQueryAgainstGqlEndpoint(DiseaseSummaryFragment("OTGenetics_OpenTargetsGeneticsSummary"))
     }
+    "return a valid response for Open Targets Projects summary fragments" taggedAs IntegrationTestTag in {
+      testQueryAgainstGqlEndpoint(DiseaseSummaryFragment("OTProjects_OTProjectsSummaryFragment"))
+    }
     "return a valid response for orphanet summary fragment" taggedAs IntegrationTestTag in {
       testQueryAgainstGqlEndpoint(DiseaseSummaryFragment("Orphanet_OrphanetSummaryFragment"))
     }
@@ -366,6 +369,12 @@ class GqlTest
   "OT genetics queries" must {
     "return valid responses" taggedAs IntegrationTestTag in {
       testQueryAgainstGqlEndpoint(TargetDiseaseSize("OTGenetics_sectionQuery"))
+    }
+  }
+
+  "OT projects queries" must {
+    "return valid responses" taggedAs IntegrationTestTag in {
+      testQueryAgainstGqlEndpoint(Disease("OTProjects_OTProjectsQuery"))
     }
   }
 

--- a/test/resources/gqlQueries/Chembl_ChemblQuery.gql
+++ b/test/resources/gqlQueries/Chembl_ChemblQuery.gql
@@ -15,8 +15,8 @@ query ChemblQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
         }
         target {
           id
+          approvedSymbol
         }
-        targetFromSourceId
         drug {
           id
           name
@@ -31,6 +31,7 @@ query ChemblQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
             }
           }
         }
+        targetFromSourceId
         clinicalPhase
         clinicalStatus
         studyStartDate

--- a/test/resources/gqlQueries/KnownDrugs_KnownDrugsQuery.gql
+++ b/test/resources/gqlQueries/KnownDrugs_KnownDrugsQuery.gql
@@ -32,6 +32,10 @@ query KnownDrugsQuery(
             }
           }
         }
+        urls {
+          url
+          name
+        }
         drugType
         mechanismOfAction
         target {

--- a/test/resources/gqlQueries/OTGenetics_sectionQuery.gql
+++ b/test/resources/gqlQueries/OTGenetics_sectionQuery.gql
@@ -38,6 +38,7 @@ query OpenTargetsGeneticsQuery(
           label
         }
         resourceScore
+        projectId
       }
     }
   }

--- a/test/resources/gqlQueries/OTProjects_OTProjectsQuery.gql
+++ b/test/resources/gqlQueries/OTProjects_OTProjectsQuery.gql
@@ -1,0 +1,10 @@
+query OTProjectsQuery($efoId: String!) {
+  disease(efoId: $efoId) {
+    otarProjects {
+      otarCode
+      status
+      projectName
+      reference
+    }
+  }
+}

--- a/test/resources/gqlQueries/OTProjects_OTProjectsSummaryFragment.gql
+++ b/test/resources/gqlQueries/OTProjects_OTProjectsSummaryFragment.gql
@@ -1,0 +1,5 @@
+fragment OTProjectsSummaryFragment on Disease {
+  otarProjects {
+    status
+  }
+}

--- a/test/resources/gqlQueries/Orphanet_OrphanetQuery.gql
+++ b/test/resources/gqlQueries/Orphanet_OrphanetQuery.gql
@@ -1,0 +1,31 @@
+query OrphanetQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
+  disease(efoId: $efoId) {
+    id
+    evidences(
+      ensemblIds: [$ensemblId]
+      enableIndirect: true
+      datasourceIds: ["orphanet"]
+      size: $size
+    ) {
+      count
+      rows {
+        target {
+          id
+          approvedSymbol
+        }
+        disease {
+          id
+          name
+        }
+        diseaseFromSource
+        diseaseFromSourceId
+        diseaseFromSourceMappedId
+        targetFromSource
+        targetFromSourceId
+        alleleOrigins
+        confidence
+        literature
+      }
+    }
+  }
+}

--- a/test/resources/gqlQueries/Orphanet_OrphanetSummaryFragment.gql
+++ b/test/resources/gqlQueries/Orphanet_OrphanetSummaryFragment.gql
@@ -1,0 +1,10 @@
+fragment OrphanetSummaryFragment on Disease {
+  orphanetSummary: evidences(
+    ensemblIds: [$ensgId]
+    enableIndirect: true
+    datasourceIds: ["orphanet"]
+    size: 0
+  ) {
+    count
+  }
+}


### PR DESCRIPTION
Adding new test cases and improving output of sbt helper method.

The sbt helper `updateGqlFiles` was listing updated files as both new and updated. We now only display each file once: new it has not been seen before, updated if it is a changed version of an existing file. 