### PR TITLE
Update TEP to use new schema.

### DIFF
--- a/app/models/entities/Target.scala
+++ b/app/models/entities/Target.scala
@@ -84,7 +84,7 @@ case class GeneOntology(id: String,
 
 case class GeneOntologyLookup(id: String, name: String)
 
-case class Tep(uri: String, name: String)
+case class Tep(targetFromSource: String, url: String, disease: String, description: String)
 
 case class IdAndSource(id: String, source: String)
 

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -428,7 +428,9 @@ object Objects extends Logging {
   )
 
   implicit val tepImp = deriveObjectType[Backend, Tep](
-    ObjectTypeDescription("Target Enabling Package (TEP)")
+    ObjectTypeDescription("Target Enabling Package (TEP)"),
+    RenameField("targetFromSource", "name"),
+    RenameField("url", "uri")
   )
 
   implicit val idAndSourceImp = deriveObjectType[Backend, IdAndSource]()


### PR DESCRIPTION
I have renamed some of the fields in `Objects.scala` so the FE doesn't
break for the 21.09 release. If desired we can roll back `Objects` to
expose the new field names.

Relates to opentargets/platform#1742