### PR TITLE
Add missing disease aggregation filter.

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -577,6 +577,7 @@ class Backend @Inject()(
             Some("datatype_id.keyword"),
             size = Some(100),
             subaggs = Seq(
+              uniqueDiseasesAgg,
               TermsAggregation("aggs",
                                Some("datasource_id.keyword"),
                                size = Some(100),


### PR DESCRIPTION
Filter had been incorrectly removed in
75cb6cc42bda2cd4cc1301a90eb7d27f91c5ca6f and caused errors where there
were no datatype aggregations.

Resolves opentargets/platform#1848.