### PR TITLE
1887 result caching

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,6 @@
 align = more
 align.openParenCallSite = true
 align.openParenDefnSite = true
-align.multiline = true
 maxColumn = 100
 assumeStandardLibraryStripMargin = true
 rewrite.rules = [SortModifiers, RedundantBraces]

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_cache:
   - find $HOME/.sbt        -name "*.lock"               -print -delete
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean compile
-  - if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then sbt ++${TRAVIS_SCALA_VERSION} scalafmtCheck; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then sbt ++${TRAVIS_SCALA_VERSION} scalafmtCheck; fi
   - sbt ++$TRAVIS_SCALA_VERSION coverage "testOnly * -- -l test_configuration.IntegrationTestTag" coverageReport
   - sbt ++$TRAVIS_SCALA_VERSION dist
 deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ RUN mkdir -p /srv/app
 COPY target/universal/ot-platform-api-latest.zip /srv/app/ot-platform-api-latest.zip
 COPY production.conf /srv/app/production.conf
 COPY production.xml /srv/app/production.xml
-
 WORKDIR /srv/app
 RUN unzip ot-platform-api-latest.zip
 
 RUN chmod +x ot-platform-api-latest/bin/ot-platform-api
-ENTRYPOINT ot-platform-api-latest/bin/ot-platform-api -J-Xms2g -J-Xmx7g -J-server -Dconfig.file=/srv/app/production.conf -Dlogger.file=/srv/app/production.xml
+ENTRYPOINT ot-platform-api-latest/bin/ot-platform-api -J-Xms2g -J-Xmx7g -J-server -Dconfig.file=/srv/app/production.conf -Dlogger.file=/srv/app/production.xml -Dlogback.debug=true

--- a/app/clickhouse/rep/SeqRep.scala
+++ b/app/clickhouse/rep/SeqRep.scala
@@ -22,7 +22,7 @@ object SeqRep {
   sealed abstract class NumSeqRep[T](override val from: String, val f: String => T)(implicit
       val ct: ClassTag[T]
   ) extends SeqRep[T, Vector](from) {
-    override protected def parse(from: String): SeqT = {
+    override protected def parse(from: String): SeqT =
       if (from.nonEmpty) {
         from.length match {
           case n if n > minLenTokensForNum =>
@@ -31,7 +31,6 @@ object SeqRep {
         }
       } else
         Vector.empty
-    }
   }
 
   case class DSeqRep(override val from: String) extends NumSeqRep[Double](from, _.toDouble)
@@ -39,7 +38,7 @@ object SeqRep {
   case class LSeqRep(override val from: String) extends NumSeqRep[Long](from, _.toLong)
 
   case class StrSeqRep(override val from: String) extends SeqRep[String, Vector](from) {
-    override protected def parse(from: String): SeqT = {
+    override protected def parse(from: String): SeqT =
       if (from.nonEmpty) {
         from.length match {
           case n if n > minLenTokensForStr =>
@@ -48,13 +47,12 @@ object SeqRep {
         }
       } else
         Vector.empty
-    }
   }
 
   case class TupleSeqRep[T](override val from: String, val f: String => T)(implicit
       val ct: ClassTag[T]
   ) extends SeqRep[T, Vector](from) {
-    override protected def parse(from: String): SeqT = {
+    override protected def parse(from: String): SeqT =
       if (from.nonEmpty) {
         from.length match {
           case n if n > minLenTokensForStr =>
@@ -64,7 +62,6 @@ object SeqRep {
         }
       } else
         Vector.empty
-    }
   }
 
   object Implicits {

--- a/app/controllers/api/v4/graphql/GraphQLController.scala
+++ b/app/controllers/api/v4/graphql/GraphQLController.scala
@@ -132,7 +132,8 @@ class GraphQLController @Inject()(implicit
           .map(
             Ok(_)
               .withHeaders(
-                (GQL_OP_HEADER, queryAst.operation().get.name.getOrElse("Unknown")),
+                (GQL_OP_HEADER,
+                 queryAst.operation().map(op => op.name).getOrElse("Unknown").toString),
                 (GQL_VAR_HEADER, gqlQuery.variables.toString())
               )
           )

--- a/app/controllers/api/v4/graphql/GraphQLController.scala
+++ b/app/controllers/api/v4/graphql/GraphQLController.scala
@@ -1,62 +1,87 @@
 package controllers.api.v4.graphql
 
-import QueryMetadataHeaders.{GQL_OP_HEADER, GQL_VAR_HEADER}
-
-import javax.inject._
+import controllers.api.v4.graphql.QueryMetadataHeaders.{GQL_OP_HEADER, GQL_VAR_HEADER}
 import models.entities.TooComplexQueryError
+import models.entities.TooComplexQueryError._
 import models.{Backend, GQLSchema}
+import org.apache.http.HttpStatus
+import play.api.Logging
+import play.api.cache.AsyncCacheApi
 import play.api.libs.json._
+import play.api.mvc._
 import sangria.execution._
 import sangria.marshalling.playJson._
 import sangria.parser.{QueryParser, SyntaxError}
 
+import javax.inject._
 import scala.concurrent._
+import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-import models.entities.TooComplexQueryError._
-import play.api.Logging
-import play.api.mvc._
+
+case class GqlQuery(query: String, variables: JsObject, operation: Option[String])
 
 @Singleton
-class GraphQLController @Inject() (implicit
-    ec: ExecutionContext,
-    dbTables: Backend,
-    cc: ControllerComponents,
-    metadataAction: MetadataAction
-) extends AbstractController(cc)
+class GraphQLController @Inject()(implicit
+                                  ec: ExecutionContext,
+                                  dbTables: Backend,
+                                  cache: AsyncCacheApi,
+                                  cc: ControllerComponents,
+                                  metadataAction: MetadataAction)
+    extends AbstractController(cc)
     with Logging {
 
+  private val non200CacheDuration = Duration(10, "seconds")
   def options: Action[AnyContent] = Action {
     NoContent
   }
 
   def gql(query: String, variables: Option[String], operation: Option[String]): Action[AnyContent] =
     metadataAction.async {
-      executeQuery(query, variables map parseVariables, operation)
+      cachedQuery(GqlQuery(query, (variables map parseVariables).getOrElse(Json.obj()), operation))
     }
 
   def gqlBody(): Action[JsValue] = metadataAction(parse.json).async { request =>
     val query = (request.body \ "query").as[String]
     val operation = (request.body \ "operationName").asOpt[String]
 
-    val variables = (request.body \ "variables").toOption.flatMap {
-      case JsString(vars) => Some(parseVariables(vars))
-      case obj: JsObject  => Some(obj)
-      case _              => None
-    }
+    val variables: JsObject = (request.body \ "variables").toOption.map {
+      case JsString(vars) => parseVariables(vars)
+      case obj: JsObject  => obj
+      case _              => Json.obj()
+    }.get
 
-    executeQuery(query, variables, operation)
+    cachedQuery(GqlQuery(query, variables, operation))
   }
 
   private def parseVariables(variables: String) =
     if (variables.trim == "" || variables.trim == "null") Json.obj()
     else Json.parse(variables).as[JsObject]
 
+  private def cachedQuery(gqlQuery: GqlQuery): Future[Result] = {
+    val fromCache: Future[Option[Result]] = cache.get[Result](gqlQuery.toString)
+    val cacheResult: Future[Result] = fromCache.flatMap {
+      case Some(result) => Future.successful(result)
+      case None =>
+        logger.debug(s"Cache miss on $gqlQuery")
+        val queryResult = executeQuery(gqlQuery)
+        queryResult.andThen {
+          case Success(s) =>
+            if (s.header.status == HttpStatus.SC_OK) {
+              logger.info(s"Caching 200 response on $gqlQuery")
+              cache.set(gqlQuery.toString, s)
+            } else {
+              logger.debug(s"Temporarily caching non-200 response on $gqlQuery")
+              cache.set(gqlQuery.toString, s, non200CacheDuration)
+            }
+        }
+    }
+    cacheResult
+  }
+
   private def executeQuery(
-      query: String,
-      variables: Option[JsObject],
-      operation: Option[String]
+      gqlQuery: GqlQuery
   ): Future[Result] =
-    QueryParser.parse(query) match {
+    QueryParser.parse(gqlQuery.query) match {
 
       // query parsed successfully, time to execute it!
       case Success(queryAst) =>
@@ -65,8 +90,8 @@ class GraphQLController @Inject() (implicit
             GQLSchema.schema,
             queryAst,
             dbTables,
-            operationName = operation,
-            variables = variables getOrElse Json.obj(),
+            operationName = gqlQuery.operation,
+            variables = gqlQuery.variables,
             deferredResolver = GQLSchema.resolvers,
             exceptionHandler = exceptionHandler,
             queryReducers = List(
@@ -78,15 +103,14 @@ class GraphQLController @Inject() (implicit
             Ok(_)
               .withHeaders(
                 (GQL_OP_HEADER, queryAst.operation().get.name.getOrElse("Unknown")),
-                (GQL_VAR_HEADER, variables.getOrElse(Json.obj()).toString())
+                (GQL_VAR_HEADER, gqlQuery.variables.toString())
               )
           )
           .recover {
             case error: QueryAnalysisError => BadRequest(error.resolveError)
-            case error: ErrorWithResolver => {
+            case error: ErrorWithResolver =>
               logger.error(error.getMessage)
               InternalServerError(error.resolveError)
-            }
           }
 
       // can't parse GraphQL query, return error

--- a/app/controllers/api/v4/graphql/GraphQLController.scala
+++ b/app/controllers/api/v4/graphql/GraphQLController.scala
@@ -1,5 +1,6 @@
 package controllers.api.v4.graphql
 
+import akka.stream.{ActorMaterializer, Materializer}
 import controllers.api.v4.graphql.QueryMetadataHeaders.{GQL_OP_HEADER, GQL_VAR_HEADER}
 import models.entities.TooComplexQueryError
 import models.entities.TooComplexQueryError._
@@ -23,6 +24,7 @@ case class GqlQuery(query: String, variables: JsObject, operation: Option[String
 @Singleton
 class GraphQLController @Inject()(implicit
                                   ec: ExecutionContext,
+                                  mat: Materializer,
                                   dbTables: Backend,
                                   cache: AsyncCacheApi,
                                   cc: ControllerComponents,
@@ -31,6 +33,7 @@ class GraphQLController @Inject()(implicit
     with Logging {
 
   private val non200CacheDuration = Duration(10, "seconds")
+
   def options: Action[AnyContent] = Action {
     NoContent
   }
@@ -57,25 +60,52 @@ class GraphQLController @Inject()(implicit
     if (variables.trim == "" || variables.trim == "null") Json.obj()
     else Json.parse(variables).as[JsObject]
 
+  private def responseContainsErrors(response: Result): Future[Boolean] =
+    response.body.consumeData
+      .map(_.utf8String)
+      .map(Json.parse)
+      .map { json =>
+        (json \ "errors").isDefined
+      }
+
   private def cachedQuery(gqlQuery: GqlQuery): Future[Result] = {
-    val fromCache: Future[Option[Result]] = cache.get[Result](gqlQuery.toString)
-    val cacheResult: Future[Result] = fromCache.flatMap {
-      case Some(result) => Future.successful(result)
-      case None =>
-        logger.debug(s"Cache miss on $gqlQuery")
-        val queryResult = executeQuery(gqlQuery)
-        queryResult.andThen {
-          case Success(s) =>
-            if (s.header.status == HttpStatus.SC_OK) {
-              logger.info(s"Caching 200 response on $gqlQuery")
-              cache.set(gqlQuery.toString, s)
-            } else {
-              logger.debug(s"Temporarily caching non-200 response on $gqlQuery")
-              cache.set(gqlQuery.toString, s, non200CacheDuration)
-            }
-        }
+    def cacheable(op: Option[String]): Boolean = !op.contains("IntrospectionQuery")
+
+    if (cacheable(gqlQuery.operation)) {
+      val fromCache: Future[Option[Result]] = cache.get[Result](gqlQuery.toString)
+      val cacheResult: Future[Result] = fromCache.flatMap {
+        case Some(result) => Future.successful(result)
+        case None =>
+          logger.debug(s"Cache miss on ${gqlQuery.operation}: ${gqlQuery.variables}")
+          val queryResult = executeQuery(gqlQuery)
+          queryResult.andThen {
+            case Success(s) =>
+              if (s.header.status == HttpStatus.SC_OK) {
+                /*
+                All GraphQL responses which pass basic validation return status code 200. If something went wrong a field
+                returned called 'errors'. If there were no errors, this field isn't present.
+                 */
+                responseContainsErrors(s).onComplete {
+                  case Success(hasErrors) =>
+                    if (hasErrors) {
+                      logger.info(s"Temporarily caching 200 response with errors")
+                      cache.set(gqlQuery.toString, s, non200CacheDuration)
+                    } else {
+                      logger.info(
+                        s"Caching 200 response on ${gqlQuery.operation}: ${gqlQuery.query.filter(_ >= ' ')}"
+                      )
+                      cache.set(gqlQuery.toString, s)
+                    }
+                  case Failure(exception) => logger.error(exception.getMessage)
+                }
+              }
+          }
+      }
+      cacheResult
+    } else {
+      executeQuery(gqlQuery)
     }
-    cacheResult
+
   }
 
   private def executeQuery(

--- a/app/controllers/api/v4/graphql/MetadataAction.scala
+++ b/app/controllers/api/v4/graphql/MetadataAction.scala
@@ -14,16 +14,16 @@ case class GqlRequestMetadata(
     isOT: Boolean,
     date: Timestamp,
     duration: Long,
-    operation: Option[String],
-    variables: Option[String],
+    operation: String,
+    variables: String,
     api: APIVersion,
     data: DataVersion
 )
 
-class MetadataAction @Inject() (parser: BodyParsers.Default)(implicit
-    ec: ExecutionContext,
-    config: Configuration
-) extends ActionBuilderImpl(parser)
+class MetadataAction @Inject()(parser: BodyParsers.Default)(implicit
+                                                            ec: ExecutionContext,
+                                                            config: Configuration)
+    extends ActionBuilderImpl(parser)
     with Logging {
 
   implicit val otSettings: OTSettings = loadConfigurationObject[OTSettings]("ot", config)
@@ -54,8 +54,8 @@ class MetadataAction @Inject() (parser: BodyParsers.Default)(implicit
               request.headers.hasHeader(metadataLoggingConfig.otHeader),
               new java.sql.Timestamp(System.currentTimeMillis()),
               requestTime,
-              responseHeaders.get(GQL_OP_HEADER),
-              responseHeaders.get(GQL_VAR_HEADER),
+              responseHeaders.getOrElse(GQL_OP_HEADER, ""),
+              responseHeaders.getOrElse(GQL_VAR_HEADER, ""),
               apiVersion,
               dataVersion
             )

--- a/app/controllers/api/v4/graphql/MetadataAction.scala
+++ b/app/controllers/api/v4/graphql/MetadataAction.scala
@@ -40,7 +40,7 @@ class MetadataAction @Inject() (parser: BodyParsers.Default)(implicit
     val startTime = System.currentTimeMillis()
     val result: Future[Result] = block(request)
 
-    result.map(response => {
+    result.map { response =>
       val responseHeaders = response.header.headers
       val opHeader = responseHeaders.get(GQL_OP_HEADER)
       val r = opHeader match {
@@ -67,6 +67,6 @@ class MetadataAction @Inject() (parser: BodyParsers.Default)(implicit
         case None => response
       }
       r.discardingHeader(GQL_OP_HEADER).discardingHeader(GQL_VAR_HEADER)
-    })
+    }
   }
 }

--- a/app/controllers/api/v4/rest/MetaController.scala
+++ b/app/controllers/api/v4/rest/MetaController.scala
@@ -71,7 +71,6 @@ class MetaController @Inject() (implicit
   }
 
   def healthcheck(): Action[AnyContent] = Action { _ =>
-    logger.info("Performing health-check")
     Ok(Json.toJson(backend.getStatus(true)))
   }
 }

--- a/app/esecuele/Column.scala
+++ b/app/esecuele/Column.scala
@@ -43,10 +43,9 @@ object Column {
 
   def column(name: String): Column = Column(name)
 
-  def literal[T](v: T): Column = {
+  def literal[T](v: T): Column =
     v match {
       case e: String => Column(RawExpression(s"'$e'"))
       case _         => Column(RawExpression(v.toString))
     }
-  }
 }

--- a/app/models/ClickhouseRetriever.scala
+++ b/app/models/ClickhouseRetriever.scala
@@ -26,14 +26,11 @@ class ClickhouseRetriever(dbConfig: DatabaseConfig[ClickHouseProfile], config: O
   val chSettings = config.clickhouse
 
   def getUniqList[A](of: Seq[String], from: String)(implicit
-      rconv: GetResult[A]
-  ): Future[Vector[A]] = {
+                                                    rconv: GetResult[A]): Future[Vector[A]] =
     getUniqList[A](of, Column(from))(rconv)
-  }
 
   def getUniqList[A](of: Seq[String], from: Column)(implicit
-      rconv: GetResult[A]
-  ): Future[Vector[A]] = {
+                                                    rconv: GetResult[A]): Future[Vector[A]] = {
     val s = Select(of.map(column))
     val f = From(from)
     val g = GroupBy(of.map(column))

--- a/app/models/ElasticRetrieverQueryBuilders.scala
+++ b/app/models/ElasticRetrieverQueryBuilders.scala
@@ -15,9 +15,8 @@ trait ElasticRetrieverQueryBuilders extends QueryApi with Logging {
       pagination: Pagination,
       aggs: Iterable[AbstractAggregation] = Iterable.empty,
       excludedFields: Seq[String] = Seq.empty
-  ): SearchRequest = {
+  ): SearchRequest =
     getByIndexQueryBuilder(esIndex, kv, pagination, aggs, excludedFields, must)
-  }
 
   def IndexQueryShould[A](
       esIndex: String,
@@ -25,9 +24,8 @@ trait ElasticRetrieverQueryBuilders extends QueryApi with Logging {
       pagination: Pagination,
       aggs: Iterable[AbstractAggregation] = Iterable.empty,
       excludedFields: Seq[String] = Seq.empty
-  ): SearchRequest = {
+  ): SearchRequest =
     getByIndexQueryBuilder(esIndex, kv, pagination, aggs, excludedFields, should)
-  }
 
   def getByIndexQueryBuilder[A, V](
       esIndex: String,

--- a/app/models/Helpers.scala
+++ b/app/models/Helpers.scala
@@ -10,7 +10,7 @@ object Helpers extends Logging {
   object Cursor extends Logging {
     def to(searchAfter: Option[String]): Option[JsValue] =
       searchAfter
-        .flatMap(sa => {
+        .flatMap { sa =>
           val vv =
             Try(Json.parse(Base64Engine.decode(sa)))
               .map(_.asOpt[JsValue])
@@ -30,7 +30,7 @@ object Helpers extends Logging {
           }
 
           vv
-        })
+        }
 
     def from(obj: Option[JsValue]): Option[String] =
       obj.map(jsv => Base64Engine.encode(Json.stringify(jsv))).map(new String(_))
@@ -65,10 +65,10 @@ object Helpers extends Logging {
       .getObjectList(key)
       .toArray
       .toSeq
-      .map(el => {
+      .map { el =>
         val co = el.asInstanceOf[ConfigObject]
         Json.parse(co.render(ConfigRenderOptions.concise())).as[T]
-      })
+      }
 
     defaultHarmonicDatasourceOptions
   }
@@ -78,9 +78,9 @@ object Helpers extends Logging {
     jObj
       .transform(source)
       .asOpt
-      .map(obj => {
+      .map { obj =>
         logger.trace(Json.prettyPrint(obj))
         obj.as[A]
-      })
+      }
   }
 }

--- a/app/models/db/QAOTF.scala
+++ b/app/models/db/QAOTF.scala
@@ -54,9 +54,9 @@ case class QAOTF(
   val BFilterQ: Option[Column] = BFilter flatMap { case matchStr =>
     val tokens = matchStr
       .split(" ")
-      .map(s => {
+      .map { s =>
         F.like(BData.name, F.lower(literal(s"%${s.toLowerCase.trim}%")))
-      })
+      }
       .toList
 
     tokens match {

--- a/app/models/entities/Associations.scala
+++ b/app/models/entities/Associations.scala
@@ -32,9 +32,8 @@ case class EvidenceSource(datasource: String, datatype: String)
 object Associations {
   val empty: Associations = Associations(Seq.empty, None, 0, Vector.empty)
 
-  implicit val getAssociationOTFRowFromDB: GetResult[Association] = {
-
-    GetResult(r => {
+  implicit val getAssociationOTFRowFromDB: GetResult[Association] =
+    GetResult { r =>
       val id: String = r.<<
       val score: Double = r.<<
       val tuples1: String = r.<<
@@ -62,8 +61,7 @@ object Associations {
           }
         ).rep
       )
-    })
-  }
+    }
 
   implicit val getEvidenceSourceFromDB: GetResult[EvidenceSource] =
     GetResult(r => EvidenceSource(r.<<, r.<<))

--- a/app/models/entities/Disease.scala
+++ b/app/models/entities/Disease.scala
@@ -40,15 +40,13 @@ object Disease extends Logging {
      */
     __.read[JsObject]
       .map { o =>
-        {
-          if (o.fields.map(_._1).contains("synonyms")) {
-            val cr: Seq[(String, JsValue)] = o.value("synonyms").as[JsObject].fields.to(Seq)
-            val newJsonObjects: Seq[JsObject] =
-              cr.map(xref => JsObject(Seq("relation" -> JsString(xref._1), "terms" -> xref._2)))
-            (o - "synonyms") ++ Json.obj("synonyms" -> newJsonObjects)
-          } else {
-            o
-          }
+        if (o.fields.map(_._1).contains("synonyms")) {
+          val cr: Seq[(String, JsValue)] = o.value("synonyms").as[JsObject].fields.to(Seq)
+          val newJsonObjects: Seq[JsObject] =
+            cr.map(xref => JsObject(Seq("relation" -> JsString(xref._1), "terms" -> xref._2)))
+          (o - "synonyms") ++ Json.obj("synonyms" -> newJsonObjects)
+        } else {
+          o
         }
       }
   )

--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -129,15 +129,13 @@ object Drug {
      */
     __.read[JsObject]
       .map { o =>
-        {
-          if (o.keys.contains("crossReferences")) {
-            val cr: Seq[(String, JsValue)] = o.value("crossReferences").as[JsObject].fields.to(Seq)
-            val newJsonObjects: Seq[JsObject] =
-              cr.map(xref => JsObject(Seq("source" -> JsString(xref._1), "reference" -> xref._2)))
-            (o - "crossReferences") ++ Json.obj("crossReferences" -> newJsonObjects)
-          } else {
-            o
-          }
+        if (o.keys.contains("crossReferences")) {
+          val cr: Seq[(String, JsValue)] = o.value("crossReferences").as[JsObject].fields.to(Seq)
+          val newJsonObjects: Seq[JsObject] =
+            cr.map(xref => JsObject(Seq("source" -> JsString(xref._1), "reference" -> xref._2)))
+          (o - "crossReferences") ++ Json.obj("crossReferences" -> newJsonObjects)
+        } else {
+          o
         }
       }
   )

--- a/app/models/entities/Harmonic.scala
+++ b/app/models/entities/Harmonic.scala
@@ -73,12 +73,12 @@ object Harmonic {
       .as(Some("max_hs_score"))
 
     // WARN! the propagation hack strikes again about expression atlas
-    val dsHSCols = datasources.flatMap(c => {
+    val dsHSCols = datasources.flatMap { c =>
       if (c.id == "expression_atlas")
         Harmonic.mkHSColumn(Column(c.id), hsMaxValueCol, booleanCondition)
       else
         Harmonic.mkHSColumn(Column(c.id), hsMaxValueCol, None)
-    })
+    }
 
     val dsWeightV = array(datasources.map(c => literal(c.weight))).as(Some("ds_scores_v"))
     val dsV = array(dsHSCols.withFilter(_.name.rep.endsWith("_v_hs")).map(_.name))
@@ -104,7 +104,7 @@ object Harmonic {
     val s = Select(idCol.name +: overallHS.name +: dsV.name +: Nil)
     val f = From(Column(table))
 
-    val expansionQuery = expansionTable.map(lut => {
+    val expansionQuery = expansionTable.map { lut =>
       val expCol = F.joinGet(lut.name, lut.field.get, qColValueCol).as(lut.field)
       val neighbourCol = expCol.name.as(Some("neighbour"))
       val innerSel = Query(Select(expCol +: Nil))
@@ -115,7 +115,7 @@ object Harmonic {
       ).toColumn(None)
       val inn = F.in(qCol, sel)
       F.or(F.equals(qCol, qColValueCol), inn)
-    })
+    }
 
     val pw = PreWhere(expansionQuery.getOrElse(F.equals(qCol, qColValueCol)))
     val g = GroupBy(idCol +: Nil)

--- a/app/models/entities/Interactions.scala
+++ b/app/models/entities/Interactions.scala
@@ -99,11 +99,11 @@ object Interactions extends Logging {
 
         val keys = ((obj \ "aggs" \ "buckets")
           .as[Seq[JsValue]])
-          .map(el => {
+          .map { el =>
             val k = (el \ "key").as[String]
             val v = (el \ "aggs" \ "buckets" \\ "key").take(1).head.as[String]
             JsObject(List("sourceDatabase" -> JsString(k), "databaseVersion" -> JsString(v)))
-          })
+          }
 
         keys
       case _ => Seq.empty

--- a/app/models/entities/Target.scala
+++ b/app/models/entities/Target.scala
@@ -263,17 +263,15 @@ object Target extends Logging {
   implicit val targetH2W: OWrites[TH2] = Json.writes[TH2]
 
   implicit val targetImpR: Reads[Target] = (targetH1R and targetH2R) { (t1, t2) =>
-    {
-      val tGen = Generic[Target]
-      val t1Gen = Generic[TH1]
-      val t2Gen = Generic[TH2]
+    val tGen = Generic[Target]
+    val t1Gen = Generic[TH1]
+    val t2Gen = Generic[TH2]
 
-      val ht1 = t1Gen.to(t1)
-      val ht2 = t2Gen.to(t2)
-      val ht = ht1 ::: ht2
+    val ht1 = t1Gen.to(t1)
+    val ht2 = t2Gen.to(t2)
+    val ht = ht1 ::: ht2
 
-      val c = tGen.from(ht)
-      c
-    }
+    val c = tGen.from(ht)
+    c
   }
 }

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -53,9 +53,8 @@ object Arguments {
   val ensemblIds: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] =
     Argument("ensemblIds", ListInputType(StringType), description = "List of Ensembl IDs")
   val chemblId: Argument[String] = Argument("chemblId", StringType, description = "Chembl ID")
-  val chemblIds: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] = {
+  val chemblIds: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] =
     Argument("chemblIds", ListInputType(StringType), description = "List of Chembl IDs")
-  }
   val goIds: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] =
     Argument("goIds", ListInputType(StringType), description = "List of GO IDs, eg. GO:0005515")
   val indirectEvidences: Argument[Option[Boolean]] = Argument(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,5 +1,5 @@
 # https://www.playframework.com/documentation/latest/Configuration
-play.http.secret.key="changeme"
+play.http.secret.key = "changeme"
 slick.dbs {
   default {
     profile = "clickhouse.ClickHouseProfile$"
@@ -193,19 +193,20 @@ ot {
   }
 }
 
-play.filters.disabled += play.filters.csrf.CSRFFilter
-play.filters.disabled += play.filters.headers.SecurityHeadersFilter
-play.filters.disabled += play.filters.csp.CSPFilter
-play.filters.disabled += play.filters.hosts.AllowedHostsFilter
-play.filters.enabled += play.filters.cors.CORSFilter
-
 play {
+  cache {
+    caffeine {
+      defaults = {
+        initial-capacity = 1000
+        maximum-size = 100000
+      }
+    }
+  }
   server {
     akka {
       max-header-size = 16k
     }
   }
-
   filters {
     cors {
       serveForbiddenOrigins = true
@@ -230,7 +231,15 @@ play {
         blackList = []
       }
     }
+    disabled = [
+      play.filters.hosts.AllowedHostsFilter,
+      play.filters.csp.CSPFilter,
+      play.filters.csrf.CSRFFilter,
+      play.filters.headers.SecurityHeadersFilter]
+    enabled = [play.filters.cors.CORSFilter]
   }
+
+
 }
 
 akka.http {

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -8,22 +8,12 @@
         </encoder>
     </appender>
 
-
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="STDOUT"/>
     </appender>
 
-    <appender name="FILEOUT" class="ch.qos.logback.core.FileAppender">
-        <!--file>${user.home}/opentargets-api-beta.log</file-->
-        <file>logs/opentargets-api-beta.log</file>
-        <append>false</append>
-        <encoder>
-            <pattern>%-5relative %-5level %logger{35} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <logger name="play" level="DEBUG"/>
-    <logger name="application" level="DEBUG"/>
+    <logger name="play" level="INFO"/>
+    <logger name="application" level="INFO"/>
     <logger name="org.apache" level="WARN"/>
     <logger name="httpclient" level="WARN"/>
     <logger name="models" level="INFO"/>
@@ -44,8 +34,6 @@
 
     <root level="INFO">
         <appender-ref ref="ASYNCSTDOUT" />
-        <appender-ref ref="FILEOUT" />
-        <appender-ref ref="STDOUT" />
     </root>
 
     <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>

--- a/production.xml
+++ b/production.xml
@@ -16,7 +16,7 @@
     <logger name="application" level="WARN"/>
     <logger name="org.apache" level="WARN"/>
     <logger name="httpclient" level="WARN"/>
-    <logger name="models" level="DEBUG"/>
+    <logger name="models" level="INFO"/>
     <logger name="controllers" level="INFO"/>
 
     <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
@@ -29,7 +29,7 @@
     <logger name="com.sksamuel.elastic4s.http.ResponseHandler" level="OFF"/>
     <logger name="akka" level="ERROR"/>
 
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 

--- a/production.xml
+++ b/production.xml
@@ -1,5 +1,4 @@
 <configuration>
-
     <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -9,10 +8,18 @@
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <!-- increases the default queue size -->
+        <queueSize>512</queueSize>
+        <!-- don't discard messages -->
+        <discardingThreshold>0</discardingThreshold>
+        <!-- block when queue is full -->
+        <neverBlock>false</neverBlock>
         <appender-ref ref="STDOUT"/>
     </appender>
 
-    <logger name="play" level="WARN"/>
+    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+
+    <logger name="play" level="INFO"/>
     <logger name="application" level="WARN"/>
     <logger name="org.apache" level="WARN"/>
     <logger name="httpclient" level="WARN"/>

--- a/test/controllers/GqlTest.scala
+++ b/test/controllers/GqlTest.scala
@@ -24,7 +24,7 @@ object GqlTest {
 
   /** Retrieves filename from target resources and returns query as string with quotes escaped.
     */
-  def getQueryFromFile(filename: String): String = {
+  def getQueryFromFile(filename: String): String =
     File(this.getClass.getResource(s"/gqlQueries/$filename.gql").getPath)
       .lines()
       .withFilter(_.nonEmpty)
@@ -32,19 +32,16 @@ object GqlTest {
         str.flatMap {
           case '"' => "\\\""
           case ch  => s"$ch"
-        }
-      )
+      })
       .mkString("\\n")
-  }
 
   def generateQueryString(query: String, variables: String): JsValue =
     Json.parse(s"""{"query": "$query" , $variables }""")
 
-  def createRequest(query: JsValue): Request[JsValue] = {
+  def createRequest(query: JsValue): Request[JsValue] =
     FakeRequest(POST, "/graphql")
       .withHeaders(("Content-Type", "application/json"))
       .withBody(query)
-  }
 }
 
 class GqlTest
@@ -126,13 +123,11 @@ class GqlTest
   "Bibliography queries" must {
     "return valid response for BibliographyQuery" taggedAs (IntegrationTestTag, ClickhouseTestTag) in {
       testQueryAgainstGqlEndpoint(Target("Bibliography_BibliographyQuery"))(t =>
-        t.replace("ensgId", "id")
-      )
+        t.replace("ensgId", "id"))
     }
     "return valid response for BibliographySimilarEntities" taggedAs (IntegrationTestTag, ClickhouseTestTag) in {
       testQueryAgainstGqlEndpoint(Target("Bibliography_SimilarEntities"))(t =>
-        t.replace("ensgId", "id")
-      )
+        t.replace("ensgId", "id"))
     }
     "return valid response for Bibliography summary fragment" taggedAs (IntegrationTestTag, ClickhouseTestTag) in {
       testQueryAgainstGqlEndpoint(DiseaseFragment("Bibliography_BibliographySummaryFragment"))
@@ -356,8 +351,7 @@ class GqlTest
   "Evidence page queries" must {
     "return valid responses " taggedAs IntegrationTestTag in {
       testQueryAgainstGqlEndpoint(TargetDisease("EvidencePage_EvidencePageQuery"))(q =>
-        q.replace("ensemblId", "ensgId")
-      )
+        q.replace("ensemblId", "ensgId"))
     }
   }
 

--- a/test/inputs/GqlCase.scala
+++ b/test/inputs/GqlCase.scala
@@ -33,7 +33,7 @@ case class AssociationDisease(file: String) extends GqlCase[(String, Aggregation
     agg <- aggregationfilterGenerator
   } yield (disease, agg)
 
-  def generateVariables(inputs: (String, AggregationFilter)) = {
+  def generateVariables(inputs: (String, AggregationFilter)) =
     s"""
       "variables": {
       "efoId": "${inputs._1}",
@@ -47,7 +47,6 @@ case class AssociationDisease(file: String) extends GqlCase[(String, Aggregation
         }]
     }
     """
-  }
 }
 
 case class AssociationTarget(file: String) extends GqlCase[(String, AggregationFilter)] {
@@ -56,7 +55,7 @@ case class AssociationTarget(file: String) extends GqlCase[(String, AggregationF
     agg <- aggregationfilterGenerator
   } yield (target, agg)
 
-  def generateVariables(inputs: (String, AggregationFilter)) = {
+  def generateVariables(inputs: (String, AggregationFilter)) =
     s"""
       "variables": {
       "ensemblId": "${inputs._1}",
@@ -70,7 +69,6 @@ case class AssociationTarget(file: String) extends GqlCase[(String, AggregationF
         }]
     }
     """
-  }
 }
 
 case class Disease(file: String) extends GqlCase[String] {
@@ -108,19 +106,18 @@ case class DiseaseAggregationfilter(file: String) extends GqlCase[(String, Aggre
 abstract class AbstractDrug extends GqlCase[String] {
   val inputGenerator = drugGenerator
 
-  override def generateVariables(drugId: String): String = {
+  override def generateVariables(drugId: String): String =
     s"""
       "variables": {
       "chemblId": "$drugId"
     }
     """
-  }
 }
 
 abstract class AbstractTarget extends GqlCase[String] {
   val inputGenerator = geneGenerator
 
-  def generateVariables(target: String): String = {
+  def generateVariables(target: String): String =
     s"""
       "variables": {
       "ensgId": "$target",
@@ -128,19 +125,17 @@ abstract class AbstractTarget extends GqlCase[String] {
       "index": 0
     }
     """
-  }
 }
 
 abstract class AbstractDisease extends GqlCase[String] {
   val inputGenerator = diseaseGenerator
 
-  def generateVariables(disease: String): String = {
+  def generateVariables(disease: String): String =
     s"""
       "variables": {
       "efoId": "$disease"
     }
     """
-  }
 }
 
 case class DrugFragment(file: String) extends AbstractDrug with GqlFragment[String] {
@@ -187,13 +182,12 @@ case class Drug(file: String) extends AbstractDrug with GqlCase[String]
 case class GeneOntology(file: String) extends GqlCase[List[String]] {
   val inputGenerator = goListGenerator
 
-  def generateVariables(inputs: List[String]): String = {
+  def generateVariables(inputs: List[String]): String =
     s"""
        "variables": {
          "goIds": "${inputs.mkString("[", ",", "]")}"
        }
      """
-  }
 }
 
 case class KnownDrugs(file: String) extends GqlCase[String] {
@@ -212,13 +206,12 @@ case class KnownDrugs(file: String) extends GqlCase[String] {
 case class Search(file: String) extends GqlCase[String] {
   override val inputGenerator = searchGenerator
 
-  def generateVariables(searchTerm: String): String = {
+  def generateVariables(searchTerm: String): String =
     s"""
       "variables": {
       "queryString": "$searchTerm"
     }
     """
-  }
 }
 
 case class SearchPage(file: String) extends GqlCase[(String, String, Int)] {
@@ -287,7 +280,7 @@ case class TargetDiseaseSize(file: String) extends GqlCase[(String, String, Int)
   def generateVariables(input: (String, String, Int)): String =
     generateVariables(input._1, input._2, input._3)
 
-  def generateVariables(target: String, disease: String, size: Int): String = {
+  def generateVariables(target: String, disease: String, size: Int): String =
     s"""
       "variables": {
       "efoId": "$disease",
@@ -295,7 +288,6 @@ case class TargetDiseaseSize(file: String) extends GqlCase[(String, String, Int)
       "size": $size
     }
     """
-  }
 }
 
 case class TargetDiseaseSizeCursor(file: String) extends GqlCase[(String, String, Int)] {
@@ -304,7 +296,7 @@ case class TargetDiseaseSizeCursor(file: String) extends GqlCase[(String, String
   def generateVariables(input: (String, String, Int)): String =
     generateVariables(input._1, input._2, input._3)
 
-  def generateVariables(target: String, disease: String, size: Int): String = {
+  def generateVariables(target: String, disease: String, size: Int): String =
     s"""
     "variables": {
       "efoId": "$disease",
@@ -313,5 +305,4 @@ case class TargetDiseaseSizeCursor(file: String) extends GqlCase[(String, String
       "cursor": null
     }
   """
-  }
 }


### PR DESCRIPTION
I've added a cache to capture successful responses. Ignore commit `6261f72`, it's just formatting changes as I work through some teething problems with `scalafmt`. 

There is no default max size for the cache, so I've gone for 100k, since most responses are less than 100kb, we should never go over 1GB of in memory cache. The container on the VM should have 7GB of memory based on the Dockerfile, so there should be no risk of us crashing with an OutOfMemory exception. Happy to hear any thoughts on this. 

I cache non-200 responses for a short time (10s) in case they are caused by a service outage with ES or CH. Hopefully this will give GCP time to recover any bad service and not create an impression for the user that the whole platform is down. 

Resolves opentargets/platform#1887