### PR TITLE
[Fix] Prevent container from getting stuck in restart loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,4 @@ ENTRYPOINT ot-platform-api-latest/bin/ot-platform-api \
     -Dcom.sun.management.jmxremote.port=31238 \
     -Dcom.sun.management.jmxremote.ssl=false \
     -Dcom.sun.management.jmxremote.authenticate=false \
+    -Dpidfile.path=/dev/null


### PR DESCRIPTION
Without the added flag (`-Dpidfile.path=/dev/null`), the Docker container would get stuck in a reboot loop (with error `This application is already running (Or delete /srv/app/ot-platform-api-latest/RUNNING_PID file).` after restarting the Docker service, e.g. when the system is rebooted.

Fix was taken from: https://stackoverflow.com/a/29244028