### PR TITLE
Fix tractability filtering.

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -385,7 +385,7 @@ class Backend @Inject() (implicit
           IndexedSeq.empty,
           nested = false
         )
-      }
+      }.toMap
     val mappings = Map(
       "dataTypes" -> AggregationMapping(
         "datatype_id",
@@ -394,7 +394,7 @@ class Backend @Inject() (implicit
       ),
       "pathwayTypes" -> AggregationMapping("facet_reactome", IndexedSeq("l1", "l2"), true),
       "targetClasses" -> AggregationMapping("facet_classes", IndexedSeq("l1", "l2"), true)
-    )
+    ) ++ tractabilityMappings
 
     val queries = ElasticRetriever.aggregationFilterProducer(aggregationFilters, mappings)
     val filtersMap = queries._2


### PR DESCRIPTION
David O observed that in the web UI filtering by tractability facets
does not actually cause the counts or heatmaps to update. This was
caused by not adding the tractability facet filter to the list of other
filters.