### PR TITLE
Changing type of studyCasesWithQualifyingVariants

### DIFF
--- a/app/models/entities/Evidence.scala
+++ b/app/models/entities/Evidence.scala
@@ -825,11 +825,11 @@ object Evidence {
       ),
       Field(
         "studyCasesWithQualifyingVariants",
-        OptionType(StringType),
+        OptionType(LongType),
         description = Some(
           "Number of cases in a case-control study that carry at least one allele of the qualifying variant"
         ),
-        resolve = js => (js.value \ "studyCasesWithQualifyingVariants").asOpt[String]
+        resolve = js => (js.value \ "studyCasesWithQualifyingVariants").asOpt[Long]
       ),
       Field(
         "variantHgvsId",


### PR DESCRIPTION
Current implementation is always returning nulls. I opened the PR because it was faster than writing a ticket, but feel free to discard and apply your own fix to the problem.

Example how the data looks like:

```
{
  "datasourceId": "gene_burden",
  "targetId": "ENSG00000108821",
  "ancestry": "EUR",
  "ancestryId": "HANCESTRO_0005",
  "cohortId": "UK Biobank 450k",
  "datatypeId": "genetic_association",
  "diseaseFromSource": "Union#Q780#Q78.0 Osteogenesis imperfecta",
  "diseaseFromSourceMappedId": "Orphanet_666",
  "literature": [
    "34375979"
  ],
  "oddsRatio": 19.9145,
  "oddsRatioConfidenceIntervalLower": 10.4606,
  "oddsRatioConfidenceIntervalUpper": 37.9122,
  "pValueExponent": -11,
  "pValueMantissa": 1.327,
  "projectId": "AstraZeneca PheWAS Portal",
  "resourceScore": 1.327e-11,
  "statisticalMethod": "flexdmg",
  "statisticalMethodOverview": "Burden test carried out with damaging variants with a MAF smaller than 0.01%.",
  "studyCases": 53,
  "studyCasesWithQualifyingVariants": 12,
  "studySampleSize": 394692,
  "targetFromSourceId": "COL1A1",
  "diseaseId": "Orphanet_666",
  "id": "ffed8fc478366913757356a76bd683bc41ab1a27",
  "score": 0.5407846807851673
}
```