### PR TITLE
Return total number of publications, cursor size.

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -813,7 +813,7 @@ class Backend @Inject() (implicit
             val npag = pag.next
             Helpers.Cursor.from(Some(Json.toJson(npag)))
           }
-          Publications(pubs.size, nCursor, pubs)
+          Publications(total, nCursor, pubs)
         }
       case _ =>
         logger.info(s"there is no publications with this set of ids $ids")


### PR DESCRIPTION
Platform API in production is always returning 25 literature entries. That is because we're taking the count of the returned page rather than the total.  