### PR TITLE
API metadata bug fix

### DIFF
--- a/production.conf
+++ b/production.conf
@@ -11,7 +11,7 @@ ot.meta.apiVersion {
               x = ${?CONFIG_OT_META_APIVERSION_MAJOR}
               y = 09
               y = ${?CONFIG_OT_META_APIVERSION_MINOR}
-              z = 2
+              z = 3
               z = ${?CONFIG_OT_META_APIVERSION_PATCH}
             }
 

--- a/production.conf
+++ b/production.conf
@@ -9,16 +9,16 @@ play.http.secret.key = ${?PLAY_SECRET}
 ot.meta.apiVersion {
               x = 22
               x = ${?CONFIG_OT_META_APIVERSION_MAJOR}
-              y = 06
+              y = 09
               y = ${?CONFIG_OT_META_APIVERSION_MINOR}
-              z = 1
+              z = 2
               z = ${?CONFIG_OT_META_APIVERSION_PATCH}
             }
 
 ot.meta.dataVersion {
               year = 22
               year = ${?CONFIG_OT_META_DATAVERSION_YEAR}
-              month = 06
+              month = 09
               month = ${?CONFIG_OT_META_DATAVERSION_MONTH}
               iteration = 0
               iteration = ${?CONFIG_OT_META_DATAVERSION_ITERATION}


### PR DESCRIPTION
This PR fixes the API metadata information, and tags the patch as release _22.09.3_
