### PR TITLE
Fix the API request to clear the cache

### DIFF
--- a/app/controllers/api/v4/rest/CacheController.scala
+++ b/app/controllers/api/v4/rest/CacheController.scala
@@ -3,6 +3,7 @@ package controllers.api.v4.rest
 import javax.inject.Inject
 import models.gql.Fetchers
 import play.api.Logging
+import play.api.cache.AsyncCacheApi
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,7 +11,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class CacheController @Inject() (implicit
     ec: ExecutionContext,
     cc: ControllerComponents,
-    restHelpers: RestHelpers
+    restHelpers: RestHelpers,
+    gqlQueryCache: AsyncCacheApi
 ) extends AbstractController(cc)
     with Logging {
 
@@ -19,6 +21,7 @@ class CacheController @Inject() (implicit
       Future {
         logger.info("Received request to clear cache.")
         Fetchers.resetCache()
+        gqlQueryCache.removeAll()
         Ok("Cache cleared.")
       }
     })

--- a/test/controllers/CacheControllerTest.scala
+++ b/test/controllers/CacheControllerTest.scala
@@ -56,9 +56,10 @@ class CacheControllerTest
       assert(drugCache.get("CHEMBL221959").isDefined)
 
       // when: the cache is cleared
-      controller.clearCache()
+      val clearRequest = FakeRequest(GET, "/cache/clear").withHeaders(("apiKey", apiKey))
+      Await.result(controller.clearCache().apply(clearRequest), 2.second)
       // then: the cache is empty
-      drugCache.get("CHEMBL221959").isDefined mustBe true
+      drugCache.get("CHEMBL221959").isDefined mustBe false
     }
   }
   "A request to clear the cache" must {


### PR DESCRIPTION
The layer of caching added in PR #97 / issue opentargets/issues#1887 was    
untouched by the command to reset caches that had been added in PR #31 /    
issue opentargets/issues#1310, rendering the command nearly useless as    
repeat GraphQL queries no longer reached the database-layer caches that    
did get cleared by the command.

Also fix the test for the original layer of caching, which would not
have turned red if it broke.