### PR TITLE
Use a maintained Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:11
+FROM eclipse-temurin:11
+RUN apt-get update \
+    && apt-get install -y unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /srv/app
 
 COPY target/universal/ot-platform-api-latest.zip /srv/app/ot-platform-api-latest.zip


### PR DESCRIPTION
As noted in previous pull requests, openjdk:11 has been accruing known security vulnerabilities (all but one of the 56 critical ones listed on <https://quay.io/repository/opentargets/platform-api?tab=tags>) since it was retired in July 2022 in favour of builds maintained by other parties, such as Eclipse Temurin. This was announced on `https://github.com/docker-library/openjdk/issues/505`.