### PR TITLE
Bump Scala minor release to fix vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: scala
 scala:
-  - 2.13.7
+  - 2.13.10
 dist: xenial
 jdk:
   - openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ version := "latest"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayLogback)
 
-scalaVersion := "2.13.7"
+scalaVersion := "2.13.10"
 maintainer := "ops@opentargets.org"
 
 javacOptions ++= Seq("-encoding", "UTF-8")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.4")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.32")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.7")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")


### PR DESCRIPTION
Scala 2.13.9 addressed some potential security issues, including one that could make code that doesn't explicitly look like it should do so allow users to make the server-side JVM run arbitrary code. Scala 2.13.10 was released soon after, mostly to fix regressions that were also introduced in 2.13.9.