### PR TITLE
3112 ignore cache

### DIFF
--- a/app/models/entities/Configuration.scala
+++ b/app/models/entities/Configuration.scala
@@ -9,8 +9,6 @@ object Configuration {
 
   case class Logging(otHeader: String, ignoredQueries: Seq[String])
 
-  case class Cache(ignoreCache: Boolean)
-
   case class DataVersion(year: String, month: String, iteration: String)
 
   case class APIVersion(x: String, y: String, z: String)
@@ -90,18 +88,17 @@ object Configuration {
   implicit val clickhouseSettingsJSONImp: OFormat[ClickhouseSettings] =
     Json.format[ClickhouseSettings]
 
-//  implicit val otSettingsJSONImp: OFormat[OTSettings] = Json.format[OTSettings]
-  implicit val otSettingsJSONImp: Reads[OTSettings] = (
-    (__ \ "meta").read[Meta] and
-      (__ \ "elasticsearch").read[ElasticsearchSettings] and
-      (__ \ "clickhouse").read[ClickhouseSettings] and
-      (__ \ "ignoreCache").read[String] and
-      (__ \ "logging").read[Logging]
-  )(
+  implicit val otSettingsJSONImp: Reads[OTSettings] = ((__ \ "meta").read[Meta] and
+    (__ \ "elasticsearch").read[ElasticsearchSettings] and
+    (__ \ "clickhouse").read[ClickhouseSettings] and
+    (__ \ "ignoreCache").read[String] and
+    (__ \ "logging").read[Logging])(
     (meta, elasticsearchSettings, clickhouseSettings, ignoreCache, logging) =>
       OTSettings.apply(meta,
                        elasticsearchSettings,
                        clickhouseSettings,
                        ignoreCache.toBooleanOption.getOrElse(false),
-                       logging))
+                       logging
+      )
+  )
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -195,8 +195,10 @@ ot {
     // GQL servers regularly ping the server to get schema information, we don't care about this.
     ignoredQueries = ["IntrospectionQuery"]
   }
+    ignoreCache = false
 }
 
+ot.ignoreCache=${?PLATFORM_API_IGNORE_CACHE}
 ot.meta.apiVersion.x=${?META_APIVERSION_MAJOR}
 ot.meta.apiVersion.y=${?META_APIVERSION_MINOR}
 ot.meta.apiVersion.z=${?META_APIVERSION_PATCH}


### PR DESCRIPTION
- Ability to disable caching (enabled by default) by setting an environment variable, PLATFORM_API_IGNORE_CACHE, to `true`