### PR TITLE
Made number of query terms validated below a configurable threshold

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -430,7 +430,7 @@ class Backend @Inject() (implicit
       e <- defaultESSettings.entities
       if (entityNames.contains(e.name) && e.searchIndex.isDefined)
     } yield e
-    withQueryTermsNumberValidation(queryTerms, defaultOTSettings.maxNumberQueryTerms) {
+    withQueryTermsNumberValidation(queryTerms, defaultOTSettings.qValidationLimitNTerms) {
       esRetriever.getTermsResultsMapping(entities,
                                          queryTerms,
                                          pagination.getOrElse(Pagination.mkDefault)

--- a/app/models/entities/Configuration.scala
+++ b/app/models/entities/Configuration.scala
@@ -65,6 +65,7 @@ object Configuration {
       elasticsearch: ElasticsearchSettings,
       clickhouse: ClickhouseSettings,
       ignoreCache: Boolean,
+      maxNumberQueryTerms: Int,
       logging: Logging
   )
 
@@ -92,12 +93,14 @@ object Configuration {
     (__ \ "elasticsearch").read[ElasticsearchSettings] and
     (__ \ "clickhouse").read[ClickhouseSettings] and
     (__ \ "ignoreCache").read[String] and
+    (__ \ "maxNumberQueryTerms").read[String] and
     (__ \ "logging").read[Logging])(
-    (meta, elasticsearchSettings, clickhouseSettings, ignoreCache, logging) =>
+    (meta, elasticsearchSettings, clickhouseSettings, ignoreCache, maxNumberQueryTerms, logging) =>
       OTSettings.apply(meta,
                        elasticsearchSettings,
                        clickhouseSettings,
                        ignoreCache.toBooleanOption.getOrElse(false),
+                       maxNumberQueryTerms.toInt,
                        logging
       )
   )

--- a/app/models/entities/Configuration.scala
+++ b/app/models/entities/Configuration.scala
@@ -65,7 +65,7 @@ object Configuration {
       elasticsearch: ElasticsearchSettings,
       clickhouse: ClickhouseSettings,
       ignoreCache: Boolean,
-      maxNumberQueryTerms: Int,
+      qValidationLimitNTerms: Int,
       logging: Logging
   )
 
@@ -93,14 +93,20 @@ object Configuration {
     (__ \ "elasticsearch").read[ElasticsearchSettings] and
     (__ \ "clickhouse").read[ClickhouseSettings] and
     (__ \ "ignoreCache").read[String] and
-    (__ \ "maxNumberQueryTerms").read[String] and
+    (__ \ "qValidationLimitNTerms").read[String] and
     (__ \ "logging").read[Logging])(
-    (meta, elasticsearchSettings, clickhouseSettings, ignoreCache, maxNumberQueryTerms, logging) =>
+    (meta,
+     elasticsearchSettings,
+     clickhouseSettings,
+     ignoreCache,
+     qValidationLimitNTerms,
+     logging
+    ) =>
       OTSettings.apply(meta,
                        elasticsearchSettings,
                        clickhouseSettings,
                        ignoreCache.toBooleanOption.getOrElse(false),
-                       maxNumberQueryTerms.toInt,
+                       qValidationLimitNTerms.toInt,
                        logging
       )
   )

--- a/app/models/entities/TooComplexQueryError.scala
+++ b/app/models/entities/TooComplexQueryError.scala
@@ -2,6 +2,7 @@ package models.entities
 
 import akka.http.scaladsl.model.DateTime
 import models.entities.Violations.InputParameterCheckError
+import models.gql.validators.InvalidQueryTerms
 import sangria.execution.{ExceptionHandler, HandledException, MaxQueryDepthReachedError}
 import sangria.marshalling.ResultMarshaller
 
@@ -28,6 +29,7 @@ case object TooComplexQueryError extends Exception("Query is too expensive.") {
     case (_, error @ TooComplexQueryError)         => HandledException(error.getMessage)
     case (_, error @ MaxQueryDepthReachedError(_)) => HandledException(error.getMessage)
     case (_, error @ InputParameterCheckError(_))  => HandledException(error.getMessage)
+    case (_, error @ InvalidQueryTerms(_))         => HandledException(error.getMessage)
     case (m, error: com.sksamuel.elastic4s.http.JavaClientExceptionWrapper) =>
       handleExceptionWithCode("Error connecting to Elasticsearch. Contact system administrator.",
                               "SOURCE_UNAVAILABLE_ELASTICSEARCH",

--- a/app/models/gql/validators/QueryTermsValidator.scala
+++ b/app/models/gql/validators/QueryTermsValidator.scala
@@ -1,0 +1,21 @@
+package models.gql.validators
+
+import scala.concurrent.Future
+
+case class InvalidQueryTerms(msg: String) extends Exception(msg)
+
+object QueryTermsValidator {
+  def withQueryTermsNumberValidation[T](
+      queryTerms: Seq[String],
+      maxNumberOfTerms: Int
+  )(callback: => Future[T]): Future[T] =
+    if (queryTerms.length > maxNumberOfTerms) {
+      Future.failed(
+        InvalidQueryTerms(
+          s"Invalid query Terms request. Number of terms must not exceed ${maxNumberOfTerms}"
+        )
+      )
+    } else {
+      callback
+    }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -200,11 +200,11 @@ ot {
     ignoredQueries = ["IntrospectionQuery"]
   }
     ignoreCache = "false"
-    maxNumberQueryTerms = "2000"
+    qValidationLimitNTerms = "2000"
 }
 
 ot.ignoreCache=${?PLATFORM_API_IGNORE_CACHE}
-ot.maxNumberQueryTerms=${?PLATFORM_API_MAX_QUERY_TERMS}
+ot.qValidationLimitNTerms=${?PLATFORM_API_MAX_QUERY_TERMS}
 ot.meta.apiVersion.x=${?META_APIVERSION_MAJOR}
 ot.meta.apiVersion.y=${?META_APIVERSION_MINOR}
 ot.meta.apiVersion.z=${?META_APIVERSION_PATCH}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -200,9 +200,11 @@ ot {
     ignoredQueries = ["IntrospectionQuery"]
   }
     ignoreCache = "false"
+    maxNumberQueryTerms = "2000"
 }
 
 ot.ignoreCache=${?PLATFORM_API_IGNORE_CACHE}
+ot.maxNumberQueryTerms=${?PLATFORM_API_MAX_QUERY_TERMS}
 ot.meta.apiVersion.x=${?META_APIVERSION_MAJOR}
 ot.meta.apiVersion.y=${?META_APIVERSION_MINOR}
 ot.meta.apiVersion.z=${?META_APIVERSION_PATCH}


### PR DESCRIPTION
- part of opentargets/issues#3114
- adding validator for number for query terms
- max number of query terms is configurable via environment variable, defaults to _2000_