### PR TITLE
fix pagination bug on mapIds endpoint 

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -422,7 +422,6 @@ class Backend @Inject() (implicit
 
   def mapIds(
       queryTerms: Seq[String],
-      pagination: Option[Pagination],
       entityNames: Seq[String]
   ): Future[MappingResults] = {
 
@@ -431,10 +430,7 @@ class Backend @Inject() (implicit
       if (entityNames.contains(e.name) && e.searchIndex.isDefined)
     } yield e
     withQueryTermsNumberValidation(queryTerms, defaultOTSettings.qValidationLimitNTerms) {
-      esRetriever.getTermsResultsMapping(entities,
-                                         queryTerms,
-                                         pagination.getOrElse(Pagination.mkDefault)
-      )
+      esRetriever.getTermsResultsMapping(entities, queryTerms)
     }
 
   }

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -93,10 +93,10 @@ object GQLSchema {
         "mapIds",
         mappingResultsImp,
         description = Some("Map terms to IDs"),
-        arguments = queryTerms :: entityNames :: pageArg :: Nil,
+        arguments = queryTerms :: entityNames :: Nil,
         resolve = ctx => {
           val entities = ctx.arg(entityNames).getOrElse(Seq.empty)
-          ctx.ctx.mapIds(ctx.arg(queryTerms), ctx.arg(pageArg), entities)
+          ctx.ctx.mapIds(ctx.arg(queryTerms), entities)
         }
       ),
       Field(


### PR DESCRIPTION
- As part of opentargets/issues#3114
- Remove pagination from mapIds endpoint and set the opensearch response size to the max 10000 when calling this endpoint