### PR TITLE
remove meddraSocCode from drug model

### DIFF
--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -16,8 +16,7 @@ case class DrugWarning(
     year: Option[Int],
     efoTerm: Option[String],
     efoId: Option[String],
-    efoIdForWarningClass: Option[String],
-    meddraSocCode: Option[String]
+    efoIdForWarningClass: Option[String]
 )
 
 case class Reference(ids: Option[Seq[String]], source: String, urls: Option[Seq[String]])
@@ -106,8 +105,7 @@ object Drug {
       (JsPath \ "year").readNullable[Int] and
       (JsPath \ "efo_term").readNullable[String] and
       (JsPath \ "efo_id").readNullable[String] and
-      (JsPath \ "efo_id_for_warning_class").readNullable[String] and
-      (JsPath \ "meddraSocCode").readNullable[String]
+      (JsPath \ "efo_id_for_warning_class").readNullable[String]
   )(DrugWarning.apply _)
   implicit val referenceImpW: OFormat[Reference] = Json.format[models.entities.Reference]
   implicit val mechanismOfActionRowImpW: OFormat[MechanismOfActionRow] =

--- a/test/resources/gqlQueries/APIPage_DrugAnnotation.gql
+++ b/test/resources/gqlQueries/APIPage_DrugAnnotation.gql
@@ -9,7 +9,6 @@ query drugApprovalWithdrawnWarningData {
       warningType
       description
       toxicityClass
-      meddraSocCode
       year
       references {
         id

--- a/test/resources/gqlQueries/DrugWarnings_DrugWarningsQuery.gql
+++ b/test/resources/gqlQueries/DrugWarnings_DrugWarningsQuery.gql
@@ -5,7 +5,6 @@ query DrugWarningsQuery($chemblId: String!) {
       warningType
       description
       toxicityClass
-      meddraSocCode
       country
       year
       efoTerm


### PR DESCRIPTION
- as part of opentargets/issues#3003
- remove drugWarning.meddraSocCode field 