### PR TITLE
filter null dates

### DIFF
--- a/app/models/db/QLITAGG.scala
+++ b/app/models/db/QLITAGG.scala
@@ -102,7 +102,7 @@ case class QLITAGG(
     val q = Q(
       Select(F.min(year) :: Nil),
       From(T),
-      PreWhere(F.in(pmid, pmidsQ(pmid :: Nil).toColumn(None)))
+      PreWhere(F.and(F.in(pmid, pmidsQ(pmid :: Nil).toColumn(None)), F.greater(year, literal(0))))
     )
 
     logger.debug(q.toString)


### PR DESCRIPTION
This item solves [2578](https://github.com/opentargets/issues/issues/2578) issue with null dates coming from EPMC by filtering out the 0 years from the min date