### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,3 @@
 FROM sbtscala/scala-sbt:eclipse-temurin-focal-11.0.17_8_1.9.0_2.13.10
+
 RUN apt-get update && apt-get install -y build-essential

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM sbtscala/scala-sbt:eclipse-temurin-focal-11.0.17_8_1.9.0_2.13.10
+RUN apt-get update && apt-get install -y build-essential

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "Scala",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"scala-lang.scala",
+				"scalameta.metals"
+			]
+		},
+		"intellij": {
+			"extensions": [
+				"org.intellij.scala"
+			]
+		}
+	},
+	"remoteUser": "sbtuser",
+	"forwardPorts": [8090],
+	"appPort": "8090:8090",
+	"runArgs": [
+		"--network=ot_platform"
+	]
+}

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,7 @@ ch_tunnel: ## Create tunnel connection to Clickhouse eg. make ch_tunnel zone eur
 	@echo "Connecting to Clickhouse"
 	@gcloud compute ssh ${instance} --zone="${zone}" --tunnel-through-iap -- -L 8123:localhost:8123
 
-.PHONY: help run_local debug_local es_tunnel ch_tunnel
+run_with_standalone: ## Runs API with standalone platform
+	@sbt "run 8090" -DELASTICSEARCH_HOST=elasticsearch -DSLICK_CLICKHOUSE_URL=jdbc:clickhouse://clickhouse:8123
+
+.PHONY: help run_local debug_local es_tunnel ch_tunnel run_with_standalone


### PR DESCRIPTION
- adding a dev container (vscode only, intellij is not supported)
- `make run_with_standalone` runs the api on the same network as the [standalone deployment](https://github.com/opentargets/standalone-deployment-platform)