### PR TITLE
3277 aotf facet filter

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -725,7 +725,8 @@ class Backend @Inject() (implicit
 
     } else Set.empty[String]
 
-    val diseaseIds = expandBIDSetWithFacetDerivedBIDs("facet_search_disease", diseaseSet, facetFilters)
+    val diseaseIds =
+      expandBIDSetWithFacetDerivedBIDs("facet_search_disease", diseaseSet, facetFilters)
     val simpleQ = aotfQ(indirectIDs, diseaseIds).simpleQuery(0, 100000)
 
     val evidencesIndexName = defaultESSettings.entities
@@ -986,17 +987,17 @@ class Backend @Inject() (implicit
       .map(_.index)
       .getOrElse(default.getOrElse(index))
 
-  private def expandBIDSetWithFacetDerivedBIDs(index: String, bIDs: Set[String], facetFilters: Seq[String]): Set[String] = {
+  private def expandBIDSetWithFacetDerivedBIDs(index: String,
+                                               bIDs: Set[String],
+                                               facetFilters: Seq[String]
+  ): Set[String] =
     if (facetFilters.isEmpty) {
       bIDs
     } else {
-      val targetsFromFacets = esRetriever.getByIds(getIndexOrDefault(index),
-                                                   facetFilters,
-                                                   fromJsValue[Facet]
-      )
+      val targetsFromFacets =
+        esRetriever.getByIds(getIndexOrDefault(index), facetFilters, fromJsValue[Facet])
       val targetIdsFromFacets =
         targetsFromFacets.await.map(_.entityIds.getOrElse(Seq.empty)).flatten.toSet
       bIDs ++ targetIdsFromFacets
     }
-  }
 }

--- a/app/models/ElasticRetriever.scala
+++ b/app/models/ElasticRetriever.scala
@@ -538,7 +538,7 @@ class ElasticRetriever @Inject() (
   ): Future[SearchFacetsResults] = {
     val limitClause = pagination.toES
     val esIndices = entities.withFilter(_.facetSearchIndex.isDefined).map(_.facetSearchIndex.get)
-    val searchFields = Seq("label", "category")
+    val searchFields = Seq("label", "category", "facetIds")
     val hlFieldSeq = searchFields.map(f => HighlightField(f))
 
     val keywordQueryFn = multiMatchQuery(qString)
@@ -558,7 +558,7 @@ class ElasticRetriever @Inject() (
 
     val fuzzyQueryFns = searchFields.map { field =>
       functionScoreQuery(
-        fuzzyQuery(field, qString)
+        matchQuery(field, qString)
           .fuzziness("AUTO")
           .prefixLength(1)
           .maxExpansions(50)

--- a/app/models/entities/SearchFacetsResults.scala
+++ b/app/models/entities/SearchFacetsResults.scala
@@ -38,7 +38,7 @@ case class SearchFacetsResults(
 
 object SearchFacetsResults {
   val empty: SearchFacetsResults = SearchFacetsResults(Seq.empty, 0)
-  
+
   implicit val FacetF: OFormat[Facet] = Json.format[Facet]
 
   implicit val SearchFacetsResultImpW: OWrites[SearchFacetsResult] =

--- a/app/models/entities/SearchFacetsResults.scala
+++ b/app/models/entities/SearchFacetsResults.scala
@@ -19,6 +19,7 @@ case class SearchFacetsResult(
     label: String,
     category: String,
     entityIds: Option[Seq[String]],
+    facetIds: Option[Seq[String]],
     score: Double,
     highlights: Seq[String]
 )
@@ -39,6 +40,7 @@ object SearchFacetsResults {
       (__ \ "_source" \ "label").read[String] and
       (__ \ "_source" \ "category").read[String] and
       (__ \ "_source" \ "entityIds").readNullable[Seq[String]] and
+      (__ \ "_source" \ "facetIds").readNullable[Seq[String]] and
       (__ \ "_score").read[Double] and
       (__ \ "highlight").readNullable[Map[String, Seq[String]]].map {
         case Some(m) =>

--- a/app/models/entities/SearchFacetsResults.scala
+++ b/app/models/entities/SearchFacetsResults.scala
@@ -12,6 +12,13 @@ case class SearchFacetsResultAggEntity(
     categories: Seq[SearchFacetsResultAggCategory]
 )
 
+case class Facet(
+    label: String,
+    category: String,
+    entityIds: Option[Seq[String]],
+    facetIds: Option[Seq[String]]
+)
+
 case class SearchFacetsResultAggs(total: Long, entities: Seq[SearchFacetsResultAggEntity])
 
 case class SearchFacetsResult(
@@ -31,6 +38,8 @@ case class SearchFacetsResults(
 
 object SearchFacetsResults {
   val empty: SearchFacetsResults = SearchFacetsResults(Seq.empty, 0)
+  
+  implicit val FacetF: OFormat[Facet] = Json.format[Facet]
 
   implicit val SearchFacetsResultImpW: OWrites[SearchFacetsResult] =
     Json.writes[models.entities.SearchFacetsResult]

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -144,7 +144,7 @@ object Arguments {
              OptionInputType(ListInputType(aggregationFilterImp)),
              description = "List of the facets to aggregate by"
     )
-  
+
   val facetFiltersListArg: Argument[Option[Seq[String]]] = Argument(
     "facetFilters",
     OptionInputType(ListInputType(StringType)),

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -144,4 +144,10 @@ object Arguments {
              OptionInputType(ListInputType(aggregationFilterImp)),
              description = "List of the facets to aggregate by"
     )
+  
+  val facetFiltersListArg: Argument[Option[Seq[String]]] = Argument(
+    "facetFilters",
+    OptionInputType(ListInputType(StringType)),
+    description = "List of the facet IDs to filter by (using OR)"
+  )
 }

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -420,12 +420,13 @@ object Objects extends Logging {
         associatedOTFTargetsImp,
         description = Some("associations on the fly"),
         arguments =
-          BIds :: indirectEvidences :: datasourceSettingsListArg :: aggregationFiltersListArg :: BFilterString :: scoreSorting :: pageArg :: Nil,
+          BIds :: indirectEvidences :: datasourceSettingsListArg :: facetFiltersListArg :: aggregationFiltersListArg :: BFilterString :: scoreSorting :: pageArg :: Nil,
         resolve = ctx =>
           ctx.ctx.getAssociationsDiseaseFixed(
             ctx.value,
             ctx arg datasourceSettingsListArg,
             ctx arg indirectEvidences getOrElse (true),
+            ctx arg facetFiltersListArg getOrElse (Seq.empty),
             ctx arg aggregationFiltersListArg getOrElse (Seq.empty),
             ctx arg BIds map (_.toSet) getOrElse (Set.empty),
             ctx arg BFilterString,

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -194,12 +194,13 @@ object Objects extends Logging {
         associatedOTFDiseasesImp,
         description = Some("associations on the fly"),
         arguments =
-          BIds :: indirectTargetEvidences :: datasourceSettingsListArg :: aggregationFiltersListArg :: BFilterString :: scoreSorting :: pageArg :: Nil,
+          BIds :: indirectTargetEvidences :: datasourceSettingsListArg :: facetFiltersListArg :: aggregationFiltersListArg :: BFilterString :: scoreSorting :: pageArg :: Nil,
         resolve = ctx =>
           ctx.ctx.getAssociationsTargetFixed(
             ctx.value,
             ctx arg datasourceSettingsListArg,
             ctx arg indirectTargetEvidences getOrElse false,
+            ctx arg facetFiltersListArg getOrElse (Seq.empty),
             ctx arg aggregationFiltersListArg getOrElse Seq.empty,
             ctx arg BIds map (_.toSet) getOrElse Set.empty,
             ctx arg BFilterString,


### PR DESCRIPTION
- for opentargets/issues#3277
- added `facetFilters` argument to the `associatedTargets` and `associatedDiseases` endpoints, which takes an array of facet IDs that can be obtained from the `facets` API. The facet Ids are subsequently resolved to expand the Bs set for BID filtering. 
- TODO: If this sufficiently replaces the `aggregationFilters` functionality, that can all be cleaned up. 