### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,113 @@
+name: Build docker image and publish to Quay.io and GAR
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: write
+      attestations: write
+      id-token: write
+
+    env:
+      TAG: ${{ github.ref_name }}
+
+    steps:
+      - id: checkout
+        name: Check out repo
+        uses: actions/checkout@v4
+
+      - id: scala-setup
+        name: Install Scala
+        uses: olafurpg/setup-scala@v11
+        with:
+          scala-version: 2.13.10
+          java-version: openjdk@1.11
+
+      - id: cache
+        name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/coursier
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+      - id: linter
+        name: Lint code
+        run: sbt scalafmtCheckAll
+
+      - id: compile
+        name: Compile code
+        run: sbt clean compile
+
+      - id: test
+        name: Run tests
+        run: sbt coverage "testOnly * -- -l test_configuration.IntegrationTestTag" coverageReport
+
+      - id: dist
+        name: Create distribution
+        run: sbt dist
+
+      - id: push-to-release
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: 'target/universal/ot-platform-api-latest.zip'
+          tags: true
+          draft: true
+
+      - id: auth_quay
+        name: Log in to quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - id: auth_google
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          project_id: 'open-targets-eu-dev'
+          workload_identity_provider: projects/426265110888/locations/global/workloadIdentityPools/github/providers/my-repo
+          service_account: pis-test-image-upload@open-targets-eu-dev.iam.gserviceaccount.com
+          access_token_lifetime: 300s
+
+      - id: auth_gar
+        name: Login to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-west1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth_google.outputs.access_token }}
+
+      - id: push
+        name: Build and push Docker image
+
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            quay.io/opentargets/platform-api-test:latest
+            quay.io/opentargets/platform-api-test:${{ github.ref_name }}
+            europe-west1-docker.pkg.dev/open-targets-eu-dev/platform-api-test/platform-api-test:latest
+            europe-west1-docker.pkg.dev/open-targets-eu-dev/platform-api-test/platform-api-test:${{ github.ref_name }}
+
+      - id: generate-attestations
+        name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: quay.io/opentargets/platform-api-test
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This PR adds a GitHub action to build and publish the API both in Quay.io and GAR.

Once this is working, we should remove the Travis integration from the repo. Also, the action should be split in two, one for the build part and another for the publish part.