### PR TITLE
Log more OpenSearch errors

### DIFF
--- a/app/controllers/api/v4/rest/MetaController.scala
+++ b/app/controllers/api/v4/rest/MetaController.scala
@@ -60,8 +60,12 @@ class MetaController @Inject() (implicit
       )
       .map(Ok(_))
       .recover {
-        case error: QueryAnalysisError => BadRequest(error.resolveError)
-        case error: ErrorWithResolver  => InternalServerError(error.resolveError)
+        case error: QueryAnalysisError =>
+          logger.error("QueryAnalysisError: " + error.getMessage())
+          BadRequest(error.resolveError)
+        case error: ErrorWithResolver =>
+          logger.error("ErrorWithResolver: " + error.getMessage())
+          InternalServerError(error.resolveError)
       }
   }
 

--- a/app/models/ElasticRetriever.scala
+++ b/app/models/ElasticRetriever.scala
@@ -46,7 +46,7 @@ class ElasticRetriever @Inject() (
             .map(_.asOpt[JsArray])
             .fold(
               ex => {
-                logger.error(s"bae64 encoded  ${ex.toString}")
+                logger.error(s"base64 encoded ${ex.toString}")
                 None
               },
               identity


### PR DESCRIPTION
Same as https://github.com/opentargets/platform-api/pull/182.

It looks like the error happening when the partner platform is unused for some time is [this exception](https://github.com/opentargets/platform-api/blob/f9c52c055e5ee05b85310aadea4a5840a0d659a8/app/models/entities/TooComplexQueryError.scala#L34).

It can still be OpenSearch is unreachable or rejecting the connection, but the message is obscured. These changes make the logs display the actual exception there.