### PR TITLE
credibleSetIds renamed to studyLocusIds

### DIFF
--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -157,15 +157,15 @@ object GQLSchema {
         ListType(credibleSetImp),
         description = None,
         arguments =
-          pageArg :: credibleSetIds :: studyIds :: diseaseIds :: variantIds :: studyTypes :: regions :: Nil,
+          pageArg :: studyLocusIds :: studyIds :: diseaseIds :: variantIds :: studyTypes :: regions :: Nil,
         resolve = ctx => {
-          val credSetIdSeq = ctx.arg(credibleSetIds).getOrElse(Seq.empty)
+          val studyLocusIdSeq = ctx.arg(studyLocusIds).getOrElse(Seq.empty)
           val studyIdSeq = ctx.arg(studyIds).getOrElse(Seq.empty)
           val diseaseIdSeq = ctx.arg(diseaseIds).getOrElse(Seq.empty)
           val variantIdSeq = ctx.arg(variantIds).getOrElse(Seq.empty)
           val studyTypesSeq = ctx.arg(studyTypes).getOrElse(Seq.empty)
           val regionsSeq = ctx.arg(regions).getOrElse(Seq.empty)
-          val credSetQueryArgs = CredibleSetQueryArgs(credSetIdSeq,
+          val credSetQueryArgs = CredibleSetQueryArgs(studyLocusIdSeq,
                                                       studyIdSeq,
                                                       diseaseIdSeq,
                                                       variantIdSeq,

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -81,10 +81,10 @@ object Arguments {
     Argument("studyTypes", OptionInputType(ListInputType(StudyType)), description = "Study types")
   val regions: Argument[Option[Seq[String]]] =
     Argument("regions", OptionInputType(ListInputType(StringType)), description = "Regions")
-  val credibleSetIds: Argument[Option[Seq[String]]] =
-    Argument("credibleSetIds",
+  val studyLocusIds: Argument[Option[Seq[String]]] =
+    Argument("studyLocusIds",
              OptionInputType(ListInputType(StringType)),
-             description = "Credible Set IDs"
+             description = "Study-locus IDs"
     )
 
   val indirectEvidences: Argument[Option[Boolean]] = Argument(


### PR DESCRIPTION
- as part of opentargets/issues#3379
- change parameter name from credibleSetIds to studyLocusIds