### PR TITLE
3395 filter required datasources after calculating scores

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -502,7 +502,8 @@ class Backend @Inject() (implicit
               assocs
             } else {
               assocs.flatMap { assoc =>
-                val filteredDS = assoc.datasourceScores.filter(ds => mustIncludeDatasources.contains(ds.id))
+                val filteredDS =
+                  assoc.datasourceScores.filter(ds => mustIncludeDatasources.contains(ds.id))
                 Some(assoc.copy(datasourceScores = filteredDS))
               }
             }

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -504,7 +504,8 @@ class Backend @Inject() (implicit
               assocs.flatMap { assoc =>
                 val filteredDS =
                   assoc.datasourceScores.filter(ds => mustIncludeDatasources.contains(ds.id))
-                Some(assoc.copy(datasourceScores = filteredDS))
+                if (filteredDS.isEmpty) None
+                else Some(assoc.copy(datasourceScores = filteredDS))
               }
             }
           }

--- a/app/models/ClickhouseRetriever.scala
+++ b/app/models/ClickhouseRetriever.scala
@@ -73,7 +73,6 @@ class ClickhouseRetriever(dbConfig: DatabaseConfig[ClickHouseProfile], config: O
       pagination: Pagination
   ): Future[Vector[Association]] = {
     val weights = datasourceSettings.map(s => (s.id, s.weight))
-    val mustIncludeDatasources = datasourceSettings.withFilter(_.required).map(_.id).toSet
     val dontPropagate = datasourceSettings.withFilter(!_.propagate).map(_.id).toSet
     val aotfQ = QAOTF(
       tableName,
@@ -83,7 +82,6 @@ class ClickhouseRetriever(dbConfig: DatabaseConfig[ClickHouseProfile], config: O
       BFilter,
       None,
       weights,
-      mustIncludeDatasources,
       dontPropagate,
       pagination.offset,
       pagination.size

--- a/app/models/db/QAOTF.scala
+++ b/app/models/db/QAOTF.scala
@@ -34,7 +34,6 @@ case class QAOTF(
     BFilter: Option[String],
     orderScoreBy: Option[(String, String)],
     datasourceWeights: Seq[(String, Double)],
-    mustIncludeDatasources: Set[String],
     nonPropagatedDatasources: Set[String],
     offset: Int,
     size: Int
@@ -90,18 +89,7 @@ case class QAOTF(
     } else {
       expressionLeft
     }
-    val expressionLeftRighWithFilters = {
-      val expressionLeftRightWithBFilter =
-        BFilterQ.map(f => F.and(f, expressionLeftRight)).getOrElse(expressionLeftRight)
-      if (mustIncludeDatasources.nonEmpty) {
-        F.and(expressionLeftRightWithBFilter,
-              F.in(DS, F.set(mustIncludeDatasources.map(literal).toSeq))
-        )
-      } else {
-        expressionLeftRightWithBFilter
-      }
-    }
-    expressionLeftRighWithFilters
+    BFilterQ.map(f => F.and(f, expressionLeftRight)).getOrElse(expressionLeftRight)
   }
 
   val DSScore: Column = F


### PR DESCRIPTION
- as part of opentargets/issues#3395
- moved datasource filter from clickhouse to backend
- scores are therefore calculated using all datasources and the "required" flag simply controls whether the datasource is returned in the response or not.