### PR TITLE
refine aotf filtering, calculate size based on clickhouse prewhere

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -485,15 +485,16 @@ class Backend @Inject() (implicit
       filter,
       orderBy,
       weights,
+      _,
       dontPropagate,
       page.offset,
       page.size
     )
-    val simpleQ = aotfQ(indirectIds, bIds).simpleQuery(0, 100000)
+    val simpleQ = aotfQ(indirectIds, bIds, mustIncludeDatasources).simpleQuery(0, 100000)
 
     (dbRetriever.executeQuery[String, Query](simpleQ)) flatMap { case assocIds =>
       val assocIdSet = assocIds.toSet
-      val fullQ = aotfQ(indirectIds, assocIdSet).query
+      val fullQ = aotfQ(indirectIds, assocIdSet, Set.empty).query
 
       if (assocIdSet.nonEmpty) {
         dbRetriever.executeQuery[Association, Query](fullQ) map { case assocs =>
@@ -505,7 +506,7 @@ class Backend @Inject() (implicit
                 val filteredDS =
                   assoc.datasourceScores.filter(ds => mustIncludeDatasources.contains(ds.id))
                 if (filteredDS.isEmpty) None
-                else Some(assoc.copy(datasourceScores = filteredDS))
+                else Some(assoc)
               }
             }
           }

--- a/app/models/ClickhouseRetriever.scala
+++ b/app/models/ClickhouseRetriever.scala
@@ -62,42 +62,4 @@ class ClickhouseRetriever(dbConfig: DatabaseConfig[ClickHouseProfile], config: O
         Vector.empty
     }
   }
-
-  def getAssociationsOTF(
-      tableName: String,
-      AId: String,
-      AIDs: Set[String],
-      BIDs: Set[String],
-      BFilter: Option[String],
-      datasourceSettings: Seq[DatasourceSettings],
-      pagination: Pagination
-  ): Future[Vector[Association]] = {
-    val weights = datasourceSettings.map(s => (s.id, s.weight))
-    val dontPropagate = datasourceSettings.withFilter(!_.propagate).map(_.id).toSet
-    val aotfQ = QAOTF(
-      tableName,
-      AId,
-      AIDs,
-      BIDs,
-      BFilter,
-      None,
-      weights,
-      dontPropagate,
-      pagination.offset,
-      pagination.size
-    ).query.as[Association]
-
-    logger.debug(aotfQ.statements.mkString(" "))
-
-    db.run(aotfQ.asTry).map {
-      case Success(v) => v
-      case Failure(ex) =>
-        logger.error(ex.toString)
-        logger.error(
-          "harmonic associations query failed " +
-            s"with query: ${aotfQ.statements.mkString(" ")}"
-        )
-        Vector.empty
-    }
-  }
 }


### PR DESCRIPTION
- as part of opentargets/issues#3395
- filter assocs where datasource "required" but don't discard datasources that are not "required"
- calculate the size of the assocs based on clickhouse query where "required" datasources are in the PREWHERE