### PR TITLE
add diseaseId arg to gwas study endpoint

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -141,6 +141,26 @@ class Backend @Inject() (implicit
     esRetriever.getByIds(indexName, ids, fromJsValue[VariantIndex])
   }
 
+  def getStudies(queryArgs: StudyQueryArgs, pagination: Option[Pagination]): Future[IndexedSeq[JsValue]] = {
+    val pag = pagination.getOrElse(Pagination.mkDefault)
+    val indexName = getIndexOrDefault("gwas_index")
+    val termsQuery = Map(
+      "studyId.keyword" -> queryArgs.id,
+      "traitFromSourceMappedIds.keyword" -> queryArgs.diseaseId
+    ).filter(_._2.nonEmpty)
+    logger.info(s"Querying studies for: $termsQuery")
+    val retriever = 
+      esRetriever
+        .getByIndexedTermsMust(
+          indexName,
+          termsQuery,
+          pag,
+          fromJsValue[JsValue]
+        )
+        .map(_._1)
+    retriever
+  }
+
   def getCredibleSets(
       queryArgs: CredibleSetQueryArgs,
       pagination: Option[Pagination]

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -149,14 +149,18 @@ object GQLSchema {
         "gwasStudy",
         ListType(gwasImp),
         description = Some("Return a Gwas Index Study"),
-        arguments = pageArg :: studyId :: diseaseId :: Nil,
+        arguments = pageArg :: studyId :: diseaseId :: enableIndirect :: Nil,
         resolve = ctx => {
-          val studyIdSeq = if (ctx.arg(studyId).isDefined) Seq(ctx.arg(studyId).get).filter(_ != "") else Seq.empty
-          val diseaseIdSeq = if (ctx.arg(diseaseId).isDefined) Seq(ctx.arg(diseaseId).get).filter(_ != "") else Seq.empty
+          val studyIdSeq =
+            if (ctx.arg(studyId).isDefined) Seq(ctx.arg(studyId).get).filter(_ != "") else Seq.empty
+          val diseaseIdSeq =
+            if (ctx.arg(diseaseId).isDefined) Seq(ctx.arg(diseaseId).get).filter(_ != "")
+            else Seq.empty
           val studyQueryArgs = StudyQueryArgs(
             studyIdSeq,
-            diseaseIdSeq
-            )
+            diseaseIdSeq,
+            ctx.arg(enableIndirect).getOrElse(false)
+          )
           ctx.ctx.getStudies(studyQueryArgs, ctx.arg(pageArg))
         }
       ),
@@ -167,12 +171,13 @@ object GQLSchema {
         arguments =
           pageArg :: studyLocusIds :: studyIds :: diseaseIds :: variantIds :: studyTypes :: regions :: Nil,
         resolve = ctx => {
-          val credSetQueryArgs = CredibleSetQueryArgs(ctx.arg(studyLocusIds).getOrElse(Seq.empty),
-                                                      ctx.arg(studyIds).getOrElse(Seq.empty),
-                                                      ctx.arg(diseaseIds).getOrElse(Seq.empty),
-                                                      ctx.arg(variantIds).getOrElse(Seq.empty),
-                                                      ctx.arg(studyTypes).getOrElse(Seq.empty),
-                                                      ctx.arg(regions).getOrElse(Seq.empty)
+          val credSetQueryArgs = CredibleSetQueryArgs(
+            ctx.arg(studyLocusIds).getOrElse(Seq.empty),
+            ctx.arg(studyIds).getOrElse(Seq.empty),
+            ctx.arg(diseaseIds).getOrElse(Seq.empty),
+            ctx.arg(variantIds).getOrElse(Seq.empty),
+            ctx.arg(studyTypes).getOrElse(Seq.empty),
+            ctx.arg(regions).getOrElse(Seq.empty)
           )
           ctx.ctx.getCredibleSets(credSetQueryArgs, ctx.arg(pageArg))
         }

--- a/app/models/entities/GwasIndex.scala
+++ b/app/models/entities/GwasIndex.scala
@@ -22,7 +22,8 @@ import models.gql.Arguments.pageArg
 
 case class StudyQueryArgs(
     id: Seq[String] = Seq.empty,
-    diseaseId: Seq[String] = Seq.empty
+    diseaseId: Seq[String] = Seq.empty,
+    enableIndirect: Boolean = false
 )
 
 object GwasIndex extends Logging {

--- a/app/models/entities/GwasIndex.scala
+++ b/app/models/entities/GwasIndex.scala
@@ -20,6 +20,11 @@ import models.entities.CredibleSet.credibleSetWithoutStudyImp
 import models.entities.CredibleSet.StudyType
 import models.gql.Arguments.pageArg
 
+case class StudyQueryArgs(
+    id: Seq[String] = Seq.empty,
+    diseaseId: Seq[String] = Seq.empty
+)
+
 object GwasIndex extends Logging {
   import sangria.macros.derive._
 

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -72,9 +72,11 @@ object Arguments {
   val variantId: Argument[String] = Argument("variantId", StringType, description = "Variant ID")
   val variantIds: Argument[Option[Seq[String]]] =
     Argument("variantIds", OptionInputType(ListInputType(StringType)), description = "Variant IDs")
-  val studyId: Argument[String] = Argument("studyId", StringType, description = "Study ID")
+  val studyId: Argument[Option[String]] = Argument("studyId", OptionInputType(StringType), description = "Study ID")
   val studyIds: Argument[Option[Seq[String]]] =
     Argument("studyIds", OptionInputType(ListInputType(StringType)), description = "Study IDs")
+  val diseaseId: Argument[Option[String]] =
+    Argument("diseaseId", OptionInputType(StringType), description = "Disease ID")
   val diseaseIds: Argument[Option[Seq[String]]] =
     Argument("diseaseIds", OptionInputType(ListInputType(StringType)), description = "Disease IDs")
   val studyTypes =

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -72,7 +72,8 @@ object Arguments {
   val variantId: Argument[String] = Argument("variantId", StringType, description = "Variant ID")
   val variantIds: Argument[Option[Seq[String]]] =
     Argument("variantIds", OptionInputType(ListInputType(StringType)), description = "Variant IDs")
-  val studyId: Argument[Option[String]] = Argument("studyId", OptionInputType(StringType), description = "Study ID")
+  val studyId: Argument[Option[String]] =
+    Argument("studyId", OptionInputType(StringType), description = "Study ID")
   val studyIds: Argument[Option[Seq[String]]] =
     Argument("studyIds", OptionInputType(ListInputType(StringType)), description = "Study IDs")
   val diseaseId: Argument[Option[String]] =
@@ -89,6 +90,11 @@ object Arguments {
              description = "Study-locus IDs"
     )
 
+  val enableIndirect: Argument[Option[Boolean]] = Argument(
+    "enableIndirect",
+    OptionInputType(BooleanType),
+    "Use the disease ontology to retrieve all its descendants and capture all their associated studies."
+  )
   val indirectEvidences: Argument[Option[Boolean]] = Argument(
     "enableIndirect",
     OptionInputType(BooleanType),


### PR DESCRIPTION
- resolves opentargets/issues#3428
- added functionality to be able to resolve gwasStudy objects by diseaseId or studyId.
- if both args are given, the intersect is returned.
- a value of `""` evaluates to an empty query, i.e. no filter is applied