### PR TITLE
add category filter and matchAll query to facets

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -444,7 +444,8 @@ class Backend @Inject() (implicit
   def searchFacets(
       qString: String,
       pagination: Option[Pagination],
-      entityNames: Seq[String]
+      entityNames: Seq[String],
+      category: Option[String]
   ): Future[SearchFacetsResults] = {
     val entities = for {
       e <- defaultESSettings.entities
@@ -452,7 +453,8 @@ class Backend @Inject() (implicit
     } yield e
     esRetriever.getSearchFacetsResultSet(entities,
                                          qString,
-                                         pagination.getOrElse(Pagination.mkDefault)
+                                         pagination.getOrElse(Pagination.mkDefault),
+                                         category
     )
   }
 

--- a/app/models/ElasticRetriever.scala
+++ b/app/models/ElasticRetriever.scala
@@ -591,12 +591,12 @@ class ElasticRetriever @Inject() (
       .field("datasourceId", 70d)
       .operator(Operator.OR)
 
-    val cateoryFilter = category match {
-      case Some(cat) => termQuery("category.keyword", cat)
+    val categoryFilter = category match {
+      case Some(categoryName) => termQuery("category.keyword", categoryName)
       case None      => matchAllQuery()
     }
 
-    val filterQueries = boolQuery().must(cateoryFilter) :: Nil
+    val filterQueries = boolQuery().must(categoryFilter) :: Nil
     val fnQueries = {
       if (qString == "*") {
         matchAllQuery() :: Nil

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -93,11 +93,11 @@ object GQLSchema {
         "facets",
         searchFacetsResultsGQLImp,
         description = Some("Search facets"),
-        arguments = optQueryString :: entityNames :: pageArg :: Nil,
+        arguments = optQueryString :: entityNames :: category :: pageArg :: Nil,
         resolve = ctx => {
           val queryString = ctx.arg(optQueryString).getOrElse("")
           val entities = ctx.arg(entityNames).getOrElse(Seq.empty)
-          ctx.ctx.searchFacets(queryString, ctx.arg(pageArg), entities)
+          ctx.ctx.searchFacets(queryString, ctx.arg(pageArg), entities, ctx.arg(category))
         }
       ),
       Field(

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -46,6 +46,8 @@ object Arguments {
     Argument("sourceDatabase", OptionInputType(StringType), description = "Database name")
   val queryString: Argument[String] =
     Argument("queryString", StringType, description = "Query string")
+  val category: Argument[Option[String]] =
+    Argument("category", OptionInputType(StringType), description = "Category")
   val queryTerms: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] =
     Argument("queryTerms", ListInputType(StringType), description = "List of query terms to map")
   val optQueryString: Argument[Option[String]] =


### PR DESCRIPTION
- resolves opentargets/issues#3442
- added optional `category` argument - which filters the results by the category value
- added a matchAll query when "*" is given as the query. 