### PR TITLE
add pagination to coloc, filter study types with opensearch

### DIFF
--- a/app/models/ElasticRetriever.scala
+++ b/app/models/ElasticRetriever.scala
@@ -169,16 +169,40 @@ class ElasticRetriever @Inject() (
       buildF: JsValue => Option[A],
       aggs: Iterable[AbstractAggregation] = Iterable.empty,
       sortByField: Option[sort.FieldSort] = None,
-      excludedFields: Seq[String] = Seq.empty
+      excludedFields: Seq[String] = Seq.empty,
+      filter: Seq[Query] = Seq.empty
   ): Future[(IndexedSeq[A], JsValue)] = {
     // just log and execute the query
     val indexQuery: IndexQuery[V] = IndexQuery(esIndex = esIndex,
                                                kv = kv,
+                                               filters = filter,
                                                pagination = pagination,
                                                aggs = aggs,
                                                excludedFields = excludedFields
     )
     val searchRequest: SearchRequest = IndexTermsMust(indexQuery)
+    getByIndexedQuery(searchRequest, sortByField, buildF)
+  }
+
+  def getByIndexedTermsShould[A, V](
+      esIndex: String,
+      kv: Map[String, V],
+      pagination: Pagination,
+      buildF: JsValue => Option[A],
+      aggs: Iterable[AbstractAggregation] = Iterable.empty,
+      sortByField: Option[sort.FieldSort] = None,
+      excludedFields: Seq[String] = Seq.empty,
+      filter: Seq[Query] = Seq.empty
+  ): Future[(IndexedSeq[A], JsValue)] = {
+    // just log and execute the query
+    val indexQuery: IndexQuery[V] = IndexQuery(esIndex = esIndex,
+                                               kv = kv,
+                                               filters = filter,
+                                               pagination = pagination,
+                                               aggs = aggs,
+                                               excludedFields = excludedFields
+    )
+    val searchRequest: SearchRequest = IndexTermsShould(indexQuery)
     getByIndexedQuery(searchRequest, sortByField, buildF)
   }
 
@@ -229,7 +253,7 @@ class ElasticRetriever @Inject() (
         case None    => searchRequest
       }
 
-      logger.debug(s"Elasticsearch query: ${client.show(sortedSearchRequest)}")
+      logger.info(s"Elasticsearch query: ${client.show(sortedSearchRequest)}")
       sortedSearchRequest
     }
 

--- a/app/models/ElasticRetrieverQueryBuilders.scala
+++ b/app/models/ElasticRetrieverQueryBuilders.scala
@@ -42,6 +42,11 @@ trait ElasticRetrieverQueryBuilders extends QueryApi with Logging {
   ): SearchRequest =
     getByIndexTermsBuilder(indexQuery, must)
 
+  def IndexTermsShould[V](
+      indexQuery: IndexQuery[V]
+  ): SearchRequest =
+    getByIndexTermsBuilder(indexQuery, should)
+
   def getByIndexQueryBuilder[V](
       indexQuery: IndexQuery[V],
       f: Iterable[Query] => BoolQuery

--- a/app/models/entities/CredibleSet.scala
+++ b/app/models/entities/CredibleSet.scala
@@ -18,7 +18,7 @@ import sangria.schema.{
   StringType,
   fields
 }
-import models.gql.Arguments.studyTypes
+import models.gql.Arguments.{studyTypes, pageArg}
 
 case class Locus(
     variantId: Option[String],
@@ -279,10 +279,10 @@ object CredibleSet extends Logging {
       "colocalisation",
       OptionType(ListType(colocalisationImp)),
       description = None,
-      arguments = studyTypes :: Nil,
+      arguments = studyTypes :: pageArg :: Nil,
       resolve = js => {
         val id = (js.value \ "studyLocusId").as[String]
-        js.ctx.getColocalisation(id, js.arg(studyTypes))
+        js.ctx.getColocalisation(id, js.arg(studyTypes), js.arg(pageArg))
       }
     )
   )


### PR DESCRIPTION
- as part of opentargets/issues#3441
- add pagination args to colocalisation endpoint