### PR TITLE
3611 scaling fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ch_tunnel: ## Create tunnel connection to Clickhouse eg. make ch_tunnel zone eur
 	@gcloud compute ssh ${instance} --zone="${zone}" --tunnel-through-iap -- -L 8123:localhost:8123
 
 run_with_standalone: ## Runs API with standalone platform
-	@sbt "run 8090" -J-Xms2g -J-Xmx7g -DELASTICSEARCH_HOST=elasticsearch -DSLICK_CLICKHOUSE_URL=jdbc:clickhouse://clickhouse:8123 -DPLATFORM_API_IGNORE_CACHE=true
+	@sbt "run 8090" -J-Xms2g -J-Xmx7g -J-XX:+UseG1GC -DELASTICSEARCH_HOST=elasticsearch -DSLICK_CLICKHOUSE_URL=jdbc:clickhouse://clickhouse:8123 -DPLATFORM_API_IGNORE_CACHE=true
 
 debug_with_standalone: ## Runs API with standalone platform
 	@sbt -jvm-debug 9999 run 8090 -DSLICK_CLICKHOUSE_URL=jdbc:clickhouse://clickhouse:8123 -DPLATFORM_API_IGNORE_CACHE=true

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -251,14 +251,14 @@ class Backend @Inject() (implicit
     retriever.map {
       case (Seq(), _, _) => None
       case (credset, _, _) =>
-        val loci = credset.flatMap(cs => (cs \ "locus").as[Seq[Locus]])
+        val loci = credset.flatMap(cs => (cs \ "locus").asOpt[Seq[Locus]].getOrElse(Seq()))
         logger.info(s"loci: $loci")
         val count = loci.size
         val filteredLoci = variantIds match {
           case Some(variantIds) => loci.filter(l => variantIds.contains(l.variantId.getOrElse("")))
           case None             => loci
         }
-        Some(Loci(count, filteredLoci.take(sizeLimit.getOrElse(Pagination.sizeDefault))))
+        Some(Loci(count, Some(filteredLoci.take(sizeLimit.getOrElse(Pagination.sizeDefault)))))
     }
   }
 

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -169,7 +169,7 @@ class Backend @Inject() (implicit
       .getByIndexedTermsMust(
         indexName,
         Map("biosampleId.keyword" -> ids),
-        Pagination.mkDefault,
+        Pagination(Pagination.indexDefault, Pagination.sizeMax),
         fromJsValue[Biosample]
       )
       .map(_._1)

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -578,8 +578,11 @@ class Backend @Inject() (implicit
       e <- defaultESSettings.entities
       if (entityNames.contains(e.name) && e.searchIndex.isDefined)
     } yield e
-    withQueryTermsNumberValidation(queryTerms, defaultOTSettings.qValidationLimitNTerms) {
-      esRetriever.getTermsResultsMapping(entities, queryTerms)
+    withQueryTermsNumberValidation(queryTerms, defaultOTSettings.qValidationLimitNTerms) match {
+      case Success(terms) =>
+        esRetriever.getTermsResultsMapping(entities, terms)
+      case Failure(error) =>
+        Future.failed(error)
     }
 
   }

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -578,12 +578,14 @@ class Backend @Inject() (implicit
       e <- defaultESSettings.entities
       if (entityNames.contains(e.name) && e.searchIndex.isDefined)
     } yield e
-    withQueryTermsNumberValidation(queryTerms, defaultOTSettings.qValidationLimitNTerms) match {
-      case Success(terms) =>
-        esRetriever.getTermsResultsMapping(entities, terms)
-      case Failure(error) =>
-        Future.failed(error)
-    }
+    esRetriever.getTermsResultsMapping(entities, queryTerms)
+
+    // withQueryTermsNumberValidation(queryTerms, defaultOTSettings.qValidationLimitNTerms) match {
+    //   case Success(terms) =>
+    //     esRetriever.getTermsResultsMapping(entities, terms)
+    //   case Failure(error) =>
+    //     Future.failed(error)
+    // }
 
   }
 

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -178,7 +178,7 @@ class Backend @Inject() (implicit
   def getStudies(queryArgs: StudyQueryArgs,
                  pagination: Option[Pagination]
   ): Future[IndexedSeq[JsValue]] = {
-    val pag = pagination.getOrElse(Pagination(Pagination.indexDefault, Pagination.sizeMax))
+    val pag = pagination.getOrElse(Pagination.mkDefault)
     val indexName = getIndexOrDefault("gwas_index")
     val diseaseIds: Seq[String] = {
       if (queryArgs.enableIndirect) {
@@ -236,7 +236,7 @@ class Backend @Inject() (implicit
       queryArgs: CredibleSetQueryArgs,
       pagination: Option[Pagination]
   ): Future[IndexedSeq[JsValue]] = {
-    val pag = pagination.getOrElse(Pagination(Pagination.indexDefault, Pagination.sizeMax))
+    val pag = pagination.getOrElse(Pagination.mkDefault)
     val indexName = getIndexOrDefault("credible_set")
     val termsQuery = Map(
       "studyLocusId.keyword" -> queryArgs.ids,

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -178,7 +178,7 @@ class Backend @Inject() (implicit
   def getStudies(queryArgs: StudyQueryArgs,
                  pagination: Option[Pagination]
   ): Future[IndexedSeq[JsValue]] = {
-    val pag = pagination.getOrElse(Pagination.mkDefault)
+    val pag = pagination.getOrElse(Pagination(Pagination.indexDefault, Pagination.sizeMax))
     val indexName = getIndexOrDefault("gwas_index")
     val diseaseIds: Seq[String] = {
       if (queryArgs.enableIndirect) {

--- a/app/models/ElasticRetriever.scala
+++ b/app/models/ElasticRetriever.scala
@@ -292,69 +292,25 @@ class ElasticRetriever @Inject() (
         (mappedHits, aggs, total)
     }
 
+  /* Provide a specific Bool Query*/
   def getQ[A](
       esIndex: String,
       boolQ: BoolQuery,
-      pageSize: Int,
+      pagination: Pagination,
       buildF: JsValue => Option[A],
       aggs: Iterable[AbstractAggregation] = Iterable.empty,
-      sortByFields: List[sort.FieldSort] = Nil,
+      sortByField: Option[sort.FieldSort] = None,
       excludedFields: Seq[String] = Seq.empty,
-      searchAfter: Option[String] = None
-  ): Future[(IndexedSeq[A], Long, Option[String])] = {
-
-    val sa: Seq[Any] = decodeSearchAfter(searchAfter).toSeq
-    val q = search(esIndex)
+  ): Future[(IndexedSeq[A], JsValue, Long)] = {
+    val limitClause = pagination.toES
+    val searchRequest: SearchRequest = search(esIndex)
       .bool(boolQ)
-      .size(pageSize)
+      .start(limitClause._1)
+      .limit(limitClause._2)
       .aggs(aggs)
       .trackTotalHits(true)
       .sourceExclude(excludedFields)
-      .searchAfter(sa)
-
-    // just log and execute the query
-    val elems: Future[Response[SearchResponse]] = client.execute {
-      val qq = sortByFields match {
-        case Nil => q
-        case _ =>
-          q.sortBy(sortByFields: _*)
-
-      }
-
-      logger.debug(s"Elasticsearch query to execute: ${client.show(qq)}")
-      qq
-    }
-
-    elems.map {
-      case _: RequestFailure                       => (IndexedSeq.empty, 0, None)
-      case results: RequestSuccess[SearchResponse] =>
-        // parse the full body response into JsValue
-        // thus, we can apply Json Transformations from JSON Play
-        val result = Json.parse(results.body.get)
-
-        logger.trace(Json.prettyPrint(result))
-        val hits = (result \ "hits" \ "hits").get.as[JsArray].value
-        val totalHits = results.result.totalHits
-
-        val mappedHits = hits
-          .map { jObj =>
-            buildF(jObj)
-          }
-          .withFilter(_.isDefined)
-          .map(_.get)
-          .to(IndexedSeq)
-
-        val hasNext = !(hits.size < pageSize) && pageSize > 0
-
-        val seAf =
-          if (hasNext) {
-            val jsa = (hits.last \ "sort").toOption
-            encodeSearchAfter(jsa)
-          } else
-            None
-
-        (mappedHits, totalHits, seAf)
-    }
+    getByIndexedQuery(searchRequest, sortByField, buildF)
   }
 
   def getByMustWithSearch[A](

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -173,7 +173,7 @@ object GQLSchema {
           pageArg :: studyLocusIds :: studyIds :: variantIds :: studyTypes :: regions :: Nil,
         resolve = ctx => {
           val credSetQueryArgs = CredibleSetQueryArgs(
-            ctx.arg(studyLocusIds).getOrElse(Seq.empty),
+            ctx.arg(studyLocusIds),
             ctx.arg(studyIds).getOrElse(Seq.empty),
             ctx.arg(variantIds).getOrElse(Seq.empty),
             ctx.arg(studyTypes).getOrElse(Seq.empty),

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -14,29 +14,14 @@ import models.entities.Interaction._
 import models.gql.Objects._
 import models.gql.Arguments._
 import models.gql.Fetchers._
+import models.gql.DeferredResolvers._
 import scala.concurrent._
 import scala.util.{Try, Failure, Success}
 
 trait GQLEntities extends Logging {}
 
 object GQLSchema {
-  val resolvers: DeferredResolver[Backend] = DeferredResolver.fetchers(
-    biosamplesFetcher,
-    credibleSetFetcher,
-    l2gFetcher,
-    targetsFetcher,
-    drugsFetcher,
-    diseasesFetcher,
-    hposFetcher,
-    reactomeFetcher,
-    expressionFetcher,
-    otarProjectsFetcher,
-    soTermsFetcher,
-    indicationFetcher,
-    goFetcher,
-    variantFetcher,
-    gwasFetcher
-  )
+  val resolvers: DeferredResolver[Backend] = deferredResolvers
 
   val query: ObjectType[Backend, Unit] = ObjectType(
     "Query",

--- a/app/models/GQLSchema.scala
+++ b/app/models/GQLSchema.scala
@@ -5,6 +5,7 @@ import play.api.libs.json._
 import sangria.schema._
 import entities._
 import models.entities.CredibleSet.credibleSetImp
+import models.entities.CredibleSets.credibleSetsImp
 import models.entities.GwasIndex.gwasImp
 import sangria.execution.deferred._
 import gql.validators.QueryTermsValidator._
@@ -170,14 +171,21 @@ object GQLSchema {
         }
       ),
       Field(
+        "credibleSet",
+        OptionType(credibleSetImp),
+        description = Some("Return a Credible Set"),
+        arguments = studyLocusId :: Nil,
+        resolve = ctx => credibleSetFetcher.deferOpt(ctx.arg(studyLocusId))
+      ),
+      Field(
         "credibleSets",
-        ListType(credibleSetImp),
+        credibleSetsImp,
         description = None,
         arguments =
           pageArg :: studyLocusIds :: studyIds :: variantIds :: studyTypes :: regions :: Nil,
         resolve = ctx => {
           val credSetQueryArgs = CredibleSetQueryArgs(
-            ctx.arg(studyLocusIds),
+            ctx.arg(studyLocusIds).getOrElse(Seq.empty),
             ctx.arg(studyIds).getOrElse(Seq.empty),
             ctx.arg(variantIds).getOrElse(Seq.empty),
             ctx.arg(studyTypes).getOrElse(Seq.empty),

--- a/app/models/entities/Configuration.scala
+++ b/app/models/entities/Configuration.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 
 object Configuration {
-  val batchSize = 5000
+  val batchSize = Pagination.sizeMax
 
   case class Logging(otHeader: String, ignoredQueries: Seq[String])
 

--- a/app/models/entities/CredibleSet.scala
+++ b/app/models/entities/CredibleSet.scala
@@ -44,7 +44,7 @@ case class Locus(
 
 case class Loci(
     count: Long,
-    rows: Seq[Locus]
+    rows: Option[Seq[Locus]]
 )
 
 case class LdSet(
@@ -116,7 +116,7 @@ object CredibleSet extends Logging {
 
   implicit val lociR: Reads[Loci] = (
     (JsPath \ "count").read[Long] and
-      (JsPath \ "locus").read[Seq[Locus]]
+      (JsPath \ "locus").readNullable[Seq[Locus]]
   )(Loci.apply _)
 
   val credibleSetFields: Seq[Field[Backend, JsValue]] = Seq(

--- a/app/models/entities/CredibleSet.scala
+++ b/app/models/entities/CredibleSet.scala
@@ -264,11 +264,11 @@ object CredibleSet extends Logging {
     Field(
       "locus",
       OptionType(lociImp),
-      arguments = variantIds :: pageSize :: Nil,
+      arguments = variantIds :: pageArg :: Nil,
       description = None,
       resolve = js => {
         val id = (js.value \ "studyLocusId").as[String]
-        js.ctx.getLocus(id, js.arg(variantIds), js.arg(pageSize))
+        js.ctx.getLocus(id, js.arg(variantIds), js.arg(pageArg))
       }
     ),
     Field(

--- a/app/models/entities/CredibleSets.scala
+++ b/app/models/entities/CredibleSets.scala
@@ -1,0 +1,23 @@
+package models.entities
+
+import models.Backend
+import models.entities.CredibleSet.credibleSetImp
+import play.api.libs.json.JsValue
+import sangria.schema.{ObjectType, Field, ListType, LongType, fields}
+
+case class CredibleSets(
+    count: Long,
+    rows: IndexedSeq[JsValue]
+)
+
+object CredibleSets {
+  def empty: CredibleSets = CredibleSets(0, IndexedSeq.empty)
+  val credibleSetsImp: ObjectType[Backend, CredibleSets] = ObjectType(
+    "CredibleSets",
+    "Credible Sets",
+    fields[Backend, CredibleSets](
+      Field("count", LongType, description = None, resolve = _.value.count),
+      Field("rows", ListType(credibleSetImp), description = None, resolve = _.value.rows)
+    )
+  )
+}

--- a/app/models/entities/GwasIndex.scala
+++ b/app/models/entities/GwasIndex.scala
@@ -232,17 +232,6 @@ object GwasIndex extends Logging {
       description = Some(""),
       resolve = js => (js.value \ "sumStatQCValues").asOpt[Seq[SumStatQC]]
     )
-    // Field(
-    //   "credibleSetCount",
-    //   IntType,
-    //   description = Some(""),
-    //   resolve = js => {
-    //     import scala.concurrent.ExecutionContext.Implicits.global
-    //     val studyId = (js.value \ "studyId").as[String]
-    //     val credSets = credibleSetFetcher.deferRelSeq(credibleSetByStudyRel, studyId)
-    //     DeferredValue(credSets).map(_.size)
-    //   }
-    // )
   )
   lazy val credibleSetField: Field[Backend, JsValue] =
     Field(

--- a/app/models/entities/Interaction.scala
+++ b/app/models/entities/Interaction.scala
@@ -279,8 +279,8 @@ object Interaction extends Logging {
     ) ++ interaction.targetB.map("targetB.keyword" -> _)
 
     esRetriever.getByIndexedQueryMust(cbIndex, kv.toMap, pag, fromJsValue[JsValue]).map {
-      case (Seq(), _) => IndexedSeq.empty
-      case (seq, _)   => seq
+      case (Seq(), _, _) => IndexedSeq.empty
+      case (seq, _, _)   => seq
     }
   }
 }

--- a/app/models/entities/Interactions.scala
+++ b/app/models/entities/Interactions.scala
@@ -70,8 +70,8 @@ object Interactions extends Logging {
         Some(sort.FieldSort("scoring", order = SortOrder.DESC))
       )
       .map {
-        case (Seq(), _) => None
-        case (seq, agg) =>
+        case (Seq(), _, _) => None
+        case (seq, agg, _) =>
           logger.debug(Json.prettyPrint(agg))
 
           val rowsCount = (agg \ "rowsCount" \ "value").as[Long]

--- a/app/models/entities/Loci.scala
+++ b/app/models/entities/Loci.scala
@@ -1,0 +1,71 @@
+package models.entities
+
+import models.Backend
+import models.entities.Pagination
+import models.gql.Fetchers.{variantFetcher}
+import models.gql.Objects.{logger, variantIndexImp}
+import play.api.Logging
+import play.api.libs.json._
+import play.api.libs.json.{Reads, JsValue, Json, OFormat, OWrites}
+import play.api.libs.functional.syntax._
+import sangria.schema.{
+  Field,
+  FloatType,
+  IntType,
+  ListType,
+  ObjectType,
+  OptionType,
+  StringType,
+  fields,
+  DeferredValue
+}
+import models.gql.Arguments.{studyTypes, pageArg, pageSize, variantIds}
+
+case class Locus(
+    variantId: Option[String],
+    posteriorProbability: Option[Double],
+    pValueMantissa: Option[Double],
+    pValueExponent: Option[Int],
+    logBF: Option[Double],
+    beta: Option[Double],
+    standardError: Option[Double],
+    is95CredibleSet: Option[Boolean],
+    is99CredibleSet: Option[Boolean],
+    r2Overall: Option[Double]
+)
+
+case class Loci(
+    count: Long,
+    rows: Option[Seq[Locus]],
+    studyLocusId: String
+)
+
+object Loci extends Logging {
+  import sangria.macros.derive._
+  def empty(): Loci = Loci(0, None, "")
+
+  implicit val locusImp: ObjectType[Backend, Locus] = deriveObjectType[Backend, Locus](
+    ReplaceField(
+      "variantId",
+      Field(
+        "variant",
+        OptionType(variantIndexImp),
+        description = None,
+        resolve = r => {
+          val variantId = r.value.variantId.getOrElse("")
+          logger.debug(s"Finding variant index: $variantId")
+          variantFetcher.deferOpt(variantId)
+        }
+      )
+    )
+  )
+
+  implicit val lociImp: ObjectType[Backend, Loci] = deriveObjectType[Backend, Loci]()
+  implicit val locusF: OFormat[Locus] = Json.format[Locus]
+  implicit val lociR: Reads[Loci] = (
+    (JsPath \ "count").read[Long] and
+      (JsPath \ "locus").readNullable[Seq[Locus]] and
+      (JsPath \ "studyLocusId").read[String]
+  )(Loci.apply _)
+
+}

--- a/app/models/entities/Pagination.scala
+++ b/app/models/entities/Pagination.scala
@@ -31,7 +31,7 @@ case class Pagination(index: Int, size: Int) {
 }
 
 object Pagination {
-  val sizeMax: Int = 5000
+  val sizeMax: Int = 10000
   val sizeDefault: Int = 25
   val indexDefault: Int = 0
 

--- a/app/models/entities/Violations.scala
+++ b/app/models/entities/Violations.scala
@@ -4,11 +4,17 @@ import sangria.execution.{UserFacingError, WithViolations}
 import sangria.validation.{BaseViolation, Violation}
 
 object Violations {
-  val paginationErrorMsg: String =
-    "There was a pagination error. You used this size %d but the max value is %d"
+  val paginationSizeErrorMsg: String =
+    "There was a pagination error. You used size %d but the size must be between 0 and %d"
 
-  case class PaginationError(currentSize: Int, sizeMax: Int = Pagination.sizeMax)
-      extends BaseViolation(paginationErrorMsg format (currentSize, sizeMax))
+  case class PaginationSizeError(currentSize: Int, sizeMax: Int = Pagination.sizeMax)
+      extends BaseViolation(paginationSizeErrorMsg format (currentSize, sizeMax))
+
+  val paginationIndexErrorMsg: String =
+    "There was a pagination error. You used index %d but the index must be 0 or greater"
+
+  case class PaginationIndexError(currentIndex: Int)
+      extends BaseViolation(paginationIndexErrorMsg format (currentIndex))
 
   case class InputParameterCheckError(violations: Vector[Violation])
       extends Exception(

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -93,9 +93,9 @@ object Arguments {
     Argument("studyTypes", OptionInputType(ListInputType(StudyType)), description = "Study types")
   val regions: Argument[Option[Seq[String]]] =
     Argument("regions", OptionInputType(ListInputType(StringType)), description = "Regions")
-  val studyLocusIds: Argument[Option[Seq[String]]] =
+  val studyLocusIds: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] =
     Argument("studyLocusIds",
-             OptionInputType(ListInputType(StringType)),
+             ListInputType(StringType),
              description = "Study-locus IDs"
     )
 

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -94,10 +94,7 @@ object Arguments {
   val regions: Argument[Option[Seq[String]]] =
     Argument("regions", OptionInputType(ListInputType(StringType)), description = "Regions")
   val studyLocusIds: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] =
-    Argument("studyLocusIds",
-             ListInputType(StringType),
-             description = "Study-locus IDs"
-    )
+    Argument("studyLocusIds", ListInputType(StringType), description = "Study-locus IDs")
 
   val enableIndirect: Argument[Option[Boolean]] = Argument(
     "enableIndirect",

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -93,9 +93,13 @@ object Arguments {
     Argument("studyTypes", OptionInputType(ListInputType(StudyType)), description = "Study types")
   val regions: Argument[Option[Seq[String]]] =
     Argument("regions", OptionInputType(ListInputType(StringType)), description = "Regions")
-  val studyLocusIds: Argument[Seq[String with tag.Tagged[FromInput.CoercedScalaResult]]] =
-    Argument("studyLocusIds", ListInputType(StringType), description = "Study-locus IDs")
-
+  val studyLocusId: Argument[String] =
+    Argument("studyLocusId", StringType, description = "Study-locus ID")
+  val studyLocusIds: Argument[Option[Seq[String]]] =
+    Argument("studyLocusIds",
+             OptionInputType(ListInputType(StringType)),
+             description = "Study-locus IDs"
+    )
   val enableIndirect: Argument[Option[Boolean]] = Argument(
     "enableIndirect",
     OptionInputType(BooleanType),

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -12,7 +12,7 @@ import sangria.util.tag
 object StudyTypeEnum extends Enumeration {
 
   type StudyType = Value
-  val gwas, tuqtl, eqtl, pqtl, sqtl = Value
+  val tuqtl, pqtl, eqtl, sqtl, sctuqtl, scpqtl, sceqtl, scsqtl, gwas = Value
 }
 
 object Arguments {

--- a/app/models/gql/DeferredResolvers.scala
+++ b/app/models/gql/DeferredResolvers.scala
@@ -1,0 +1,65 @@
+package models.gql
+import models.entities.{
+    Loci,
+    Pagination
+}
+import models.{Backend, entities}
+import play.api.Logging
+import sangria.execution.deferred.{
+  Deferred,
+  DeferredResolver,
+}
+import scala.concurrent._
+
+
+case class LocusDeferred(studyLocusId: String, variantIds: Option[Seq[String]], pagination: Option[Pagination]) extends Deferred[Loci]
+
+// TODO: Genericize this resolver to handle not just locus but other deferred types: hint - use the groupDeferred method
+class LocusResolver extends DeferredResolver[Backend] with Logging {
+    def resolve(deferred: Vector[Deferred[Any]], ctx: Backend, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]] = {
+        val lq = deferred collect {case q: LocusDeferred => q}
+        // group by variantIds and pagination so that we can use studyLocusId to fetch the loci
+        val groupedLq = lq.groupBy(q => (q.variantIds, q.pagination))
+        val locusQueries = groupedLq.map {
+            case ((variantIds, pagination), queries) =>
+                val studyLocusIds = queries.map(_.studyLocusId)
+                (studyLocusIds, variantIds, pagination)
+            }
+        // results grouped by variantIds and pagination
+        val results = locusQueries.map {
+            case (studyLocusIds, variantIds, pagination) =>
+                val r = ctx.getLocus(studyLocusIds, variantIds, pagination)
+                (variantIds, pagination) -> r
+        }.toMap
+        deferred.map {
+            case LocusDeferred(studyLocusId, variantIds, pagination) =>
+                // lookup results based on the variantIds pagination group in the results
+                val group = results.get((variantIds, pagination)).get
+                val l = group.map(loci => loci.filter(studyLocusId == _.studyLocusId))
+                l.map(_.headOption.getOrElse(Loci.empty()))
+        }
+    }
+}
+
+object DeferredResolvers extends Logging {
+    val locusResolver = new LocusResolver()
+    // add fetchers and locusResolver to the resolvers
+    val deferredResolvers: DeferredResolver[Backend] = DeferredResolver.fetchersWithFallback(
+        locusResolver,
+        Fetchers.biosamplesFetcher,
+        Fetchers.credibleSetFetcher,
+        Fetchers.l2gFetcher,
+        Fetchers.targetsFetcher,
+        Fetchers.drugsFetcher,
+        Fetchers.diseasesFetcher,
+        Fetchers.hposFetcher,
+        Fetchers.reactomeFetcher,
+        Fetchers.expressionFetcher,
+        Fetchers.otarProjectsFetcher,
+        Fetchers.soTermsFetcher,
+        Fetchers.indicationFetcher,
+        Fetchers.goFetcher,
+        Fetchers.variantFetcher,
+        Fetchers.gwasFetcher
+    ) 
+}

--- a/app/models/gql/Fetchers.scala
+++ b/app/models/gql/Fetchers.scala
@@ -13,6 +13,7 @@ import models.entities.{
   Indications,
   L2GPredictions,
   OtarProjects,
+  Pagination,
   Reactome,
   Target,
   VariantIndex
@@ -30,6 +31,7 @@ import sangria.execution.deferred.{
   SimpleFetcherCache
 }
 import models.gql.Arguments.studyId
+import scala.concurrent.java8.FuturesConvertersImpl.P
 
 object Fetchers extends Logging {
   val soTermsFetcherCache = FetcherCache.simple
@@ -161,11 +163,11 @@ object Fetchers extends Logging {
         .maxBatchSize(entities.Configuration.batchSize)
         .caching(credibleSetFetcherCache),
       fetch = (ctx: Backend, ids: Seq[String]) => {
-        ctx.getCredibleSets(entities.CredibleSetQueryArgs(ids = ids), None)
+        ctx.getCredibleSets(entities.CredibleSetQueryArgs(ids = ids), Some(Pagination.mkMax))
       },
       fetchRel = (ctx: Backend, ids: RelationIds[JsValue]) => {
         ctx.getCredibleSets(entities.CredibleSetQueryArgs(studyIds = ids(credibleSetByStudyRel)),
-                            None
+                            Some(Pagination.mkMax)
         )
       }
     )
@@ -194,7 +196,7 @@ object Fetchers extends Logging {
       config =
         FetcherConfig.maxBatchSize(entities.Configuration.batchSize).caching(gwasFetcherCache),
       fetch = (ctx: Backend, ids: Seq[String]) => {
-        ctx.getStudies(entities.StudyQueryArgs(id = ids), None)
+        ctx.getStudies(entities.StudyQueryArgs(id = ids), Some(Pagination.mkMax))
       }
     )
   }

--- a/app/models/gql/Fetchers.scala
+++ b/app/models/gql/Fetchers.scala
@@ -12,6 +12,7 @@ import models.entities.{
   HPO,
   Indications,
   L2GPredictions,
+  Loci,
   OtarProjects,
   Pagination,
   Reactome,
@@ -153,23 +154,22 @@ object Fetchers extends Logging {
   )
 
   val credibleSetFetcherCache = FetcherCache.simple
-  val credibleSetByStudyRel =
-    Relation[JsValue, String]("byStudy", js => Seq((js \ "studyId").as[String]))
+  // val credibleSetByStudyRel =
+  //   Relation[JsValue, String]("byStudy", js => Seq((js \ "studyId").as[String]))
   val credibleSetFetcher: Fetcher[Backend, JsValue, JsValue, String] = {
     implicit val credibleSetFetcherId: HasId[JsValue, String] =
       HasId[JsValue, String](js => (js \ "studyLocusId").as[String])
-    Fetcher.rel(
+    Fetcher(
       config = FetcherConfig
         .maxBatchSize(entities.Configuration.batchSize)
         .caching(credibleSetFetcherCache),
-      fetch = (ctx: Backend, ids: Seq[String]) => {
-        ctx.getCredibleSets(entities.CredibleSetQueryArgs(ids = ids), Some(Pagination.mkMax))
-      },
-      fetchRel = (ctx: Backend, ids: RelationIds[JsValue]) => {
-        ctx.getCredibleSets(entities.CredibleSetQueryArgs(studyIds = ids(credibleSetByStudyRel)),
-                            Some(Pagination.mkMax)
-        )
-      }
+      fetch = (ctx: Backend, ids: Seq[String]) => ctx.getCredibleSet(ids)
+      // },
+      // fetchRel = (ctx: Backend, ids: RelationIds[JsValue]) => {
+      //   ctx.getCredibleSets(entities.CredibleSetQueryArgs(studyIds = ids(credibleSetByStudyRel)),
+      //                       Some(Pagination.mkMax)
+      //   )
+      // }
     )
   }
 

--- a/app/models/gql/Fetchers.scala
+++ b/app/models/gql/Fetchers.scala
@@ -31,8 +31,8 @@ import sangria.execution.deferred.{
   HasId,
   SimpleFetcherCache
 }
+import scala.concurrent._
 import models.gql.Arguments.studyId
-import scala.concurrent.java8.FuturesConvertersImpl.P
 
 object Fetchers extends Logging {
   val soTermsFetcherCache = FetcherCache.simple

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -17,6 +17,7 @@ import sangria.schema._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
+import models.entities.CredibleSets.credibleSetsImp
 import models.entities.CredibleSet.credibleSetImp
 
 object Objects extends Logging {
@@ -1350,8 +1351,8 @@ object Objects extends Logging {
           resolve = r => {
             val studyLocusId = r.value.otherStudyLocusId.getOrElse("")
             logger.info(s"Finding colocalisation credible set: $studyLocusId")
-            val credSetQueryArgs = CredibleSetQueryArgs(ids = Seq(studyLocusId))
-            r.ctx.getCredibleSets(credSetQueryArgs, None).map(_.headOption)
+            // r.ctx.getCredibleSet(studyLocusId)
+            credibleSetFetcher.deferOpt(studyLocusId)
           }
         )
       ),
@@ -1378,7 +1379,7 @@ object Objects extends Logging {
       AddFields(
         Field(
           "credibleSets",
-          OptionType(ListType(credibleSetImp)),
+          credibleSetsImp,
           description = Some("Credible sets"),
           arguments = pageArg :: studyTypes :: Nil,
           resolve = r => {

--- a/app/models/gql/validators/QueryTermsValidator.scala
+++ b/app/models/gql/validators/QueryTermsValidator.scala
@@ -1,21 +1,24 @@
 package models.gql.validators
 
 import scala.concurrent.Future
+import scala.util.{Try, Failure, Success}
 
 case class InvalidQueryTerms(msg: String) extends Exception(msg)
 
 object QueryTermsValidator {
-  def withQueryTermsNumberValidation[T](
+  def withQueryTermsNumberValidation(
       queryTerms: Seq[String],
       maxNumberOfTerms: Int
-  )(callback: => Future[T]): Future[T] =
+  ): Try[Seq[String]] =
     if (queryTerms.length > maxNumberOfTerms) {
-      Future.failed(
+
+      Failure(
         InvalidQueryTerms(
-          s"Invalid query Terms request. Number of terms must not exceed ${maxNumberOfTerms}"
+          s"Invalid request. Number of requested terms must not exceed ${maxNumberOfTerms}"
         )
       )
+
     } else {
-      callback
+      Success(queryTerms)
     }
 }


### PR DESCRIPTION
- part of opentargets/issues#3611
- update study types enum
- increase max page size for elastic
- pagination validation
- singular and plural endpoints for credibleSet(s)
- add variantId filter argument to `locus`
- locus is nested type
- add deferred resolver for locus