### PR TITLE
3630 Fix typo when reading sumstat Values

### DIFF
--- a/app/models/entities/GwasIndex.scala
+++ b/app/models/entities/GwasIndex.scala
@@ -236,7 +236,7 @@ object GwasIndex extends Logging {
       "sumStatQCValues",
       OptionType(ListType(sumStatQCImp)),
       description = Some(""),
-      resolve = js => (js.value \ "sumStatQCValues").asOpt[Seq[SumStatQC]]
+      resolve = js => (js.value \ "sumstatQCValues").asOpt[Seq[SumStatQC]]
     )
     // Field(
     //   "credibleSetCount",


### PR DESCRIPTION
This item solves the issue [3630](https://github.com/opentargets/issues/issues/3630) which was caused by a typo in the field name