### PR TITLE
3642 defer all credible set resolvers

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -148,7 +148,7 @@ class Backend @Inject() (implicit
       .getByIndexedTermsMust(
         indexName,
         Map("studyLocusId.keyword" -> ids),
-        Pagination(Pagination.indexDefault, Pagination.sizeMax),
+        Pagination.mkMax,
         fromJsValue[L2GPredictions],
         sortByField = ElasticRetriever.sortBy("score", SortOrder.Desc)
       )
@@ -157,11 +157,10 @@ class Backend @Inject() (implicit
 
   def getVariants(ids: Seq[String]): Future[IndexedSeq[VariantIndex]] = {
     val indexName = getIndexOrDefault("variant_index")
-    val pag = Pagination(Pagination.indexDefault, Pagination.sizeMax)
     val r = esRetriever
       .getByIndexedTermsMust(indexName,
                              Map("variantId.keyword" -> ids),
-                             pag,
+                             Pagination.mkMax,
                              fromJsValue[VariantIndex]
       )
       .map(_.mappedHits)
@@ -174,14 +173,13 @@ class Backend @Inject() (implicit
       .getByIndexedTermsMust(
         indexName,
         Map("biosampleId.keyword" -> ids),
-        Pagination(Pagination.indexDefault, Pagination.sizeMax),
+        Pagination.mkMax,
         fromJsValue[Biosample]
       )
       .map(_.mappedHits)
   }
 
   def getStudy(ids: Seq[String]): Future[IndexedSeq[JsValue]] = {
-    val pag = Pagination.mkDefault
     val indexName = getIndexOrDefault("gwas_index")
     val termsQuery = Map("studyId.keyword" -> ids)
     val retriever =
@@ -189,7 +187,7 @@ class Backend @Inject() (implicit
         .getByIndexedTermsMust(
           indexName,
           termsQuery,
-          pag,
+          Pagination.mkMax,
           fromJsValue[JsValue]
         )
     retriever.map(_.mappedHits)
@@ -303,7 +301,6 @@ class Backend @Inject() (implicit
   }
 
   def getCredibleSet(ids: Seq[String]): Future[IndexedSeq[JsValue]] = {
-    val pag = Pagination.mkDefault
     val indexName = getIndexOrDefault("credible_set")
     val termsQuery = Map("studyLocusId.keyword" -> ids)
     val retriever =
@@ -311,7 +308,7 @@ class Backend @Inject() (implicit
         .getByIndexedTermsMust(
           indexName,
           termsQuery,
-          pag,
+          Pagination.mkMax,
           fromJsValue[JsValue],
           excludedFields = Seq("locus", "ldSet")
         )

--- a/app/models/entities/CredibleSets.scala
+++ b/app/models/entities/CredibleSets.scala
@@ -6,7 +6,6 @@ import play.api.libs.json.JsValue
 import sangria.schema.{ObjectType, Field, ListType, LongType, fields}
 import models.gql.TypeWithId
 
-
 case class CredibleSets(
     count: Long,
     rows: IndexedSeq[JsValue],

--- a/app/models/entities/CredibleSets.scala
+++ b/app/models/entities/CredibleSets.scala
@@ -4,11 +4,14 @@ import models.Backend
 import models.entities.CredibleSet.credibleSetImp
 import play.api.libs.json.JsValue
 import sangria.schema.{ObjectType, Field, ListType, LongType, fields}
+import models.gql.TypeWithId
+
 
 case class CredibleSets(
     count: Long,
-    rows: IndexedSeq[JsValue]
-)
+    rows: IndexedSeq[JsValue],
+    id: String = ""
+) extends TypeWithId
 
 object CredibleSets {
   def empty: CredibleSets = CredibleSets(0, IndexedSeq.empty)

--- a/app/models/entities/Interaction.scala
+++ b/app/models/entities/Interaction.scala
@@ -5,6 +5,7 @@ import models.Helpers.fromJsValue
 import models.entities.Configuration.ElasticsearchSettings
 import models.gql.Fetchers.targetsFetcher
 import models.gql.Objects.targetImp
+import models.Results
 import play.api.Logging
 import play.api.libs.json._
 import sangria.schema._
@@ -279,8 +280,8 @@ object Interaction extends Logging {
     ) ++ interaction.targetB.map("targetB.keyword" -> _)
 
     esRetriever.getByIndexedQueryMust(cbIndex, kv.toMap, pag, fromJsValue[JsValue]).map {
-      case (Seq(), _, _) => IndexedSeq.empty
-      case (seq, _, _)   => seq
+      case Results(Seq(), _, _, _) => IndexedSeq.empty
+      case Results(seq, _, _, _)   => seq
     }
   }
 }

--- a/app/models/entities/Interactions.scala
+++ b/app/models/entities/Interactions.scala
@@ -9,6 +9,7 @@ import models.Helpers.fromJsValue
 import models.{Backend, ElasticRetriever}
 import models.entities.Configuration.ElasticsearchSettings
 import models.entities.Interaction.interaction
+import models.Results
 import play.api.Logging
 import play.api.libs.json._
 import sangria.schema.{Field, ListType, LongType, ObjectType, fields}
@@ -70,8 +71,8 @@ object Interactions extends Logging {
         Some(sort.FieldSort("scoring", order = SortOrder.DESC))
       )
       .map {
-        case (Seq(), _, _) => None
-        case (seq, agg, _) =>
+        case Results(Seq(), _, _, _) => None
+        case Results(seq, agg, _, _) =>
           logger.debug(Json.prettyPrint(agg))
 
           val rowsCount = (agg \ "rowsCount" \ "value").as[Long]

--- a/app/models/entities/Loci.scala
+++ b/app/models/entities/Loci.scala
@@ -9,6 +9,7 @@ import play.api.libs.json._
 import play.api.libs.json.{Reads, JsValue, Json, OFormat, OWrites}
 import play.api.libs.functional.syntax._
 import sangria.schema.{
+  DeferredValue,
   Field,
   FloatType,
   IntType,
@@ -17,9 +18,9 @@ import sangria.schema.{
   OptionType,
   StringType,
   fields,
-  DeferredValue
 }
 import models.gql.Arguments.{studyTypes, pageArg, pageSize, variantIds}
+import models.gql.TypeWithId
 
 case class Locus(
     variantId: Option[String],
@@ -37,8 +38,8 @@ case class Locus(
 case class Loci(
     count: Long,
     rows: Option[Seq[Locus]],
-    studyLocusId: String
-)
+    id: String
+) extends TypeWithId 
 
 object Loci extends Logging {
   import sangria.macros.derive._
@@ -60,7 +61,9 @@ object Loci extends Logging {
     )
   )
 
-  implicit val lociImp: ObjectType[Backend, Loci] = deriveObjectType[Backend, Loci]()
+  implicit val lociImp: ObjectType[Backend, Loci] = deriveObjectType[Backend, Loci](
+    ExcludeFields("id"),
+  )
   implicit val locusF: OFormat[Locus] = Json.format[Locus]
   implicit val lociR: Reads[Loci] = (
     (JsPath \ "count").read[Long] and

--- a/app/models/entities/Loci.scala
+++ b/app/models/entities/Loci.scala
@@ -17,7 +17,7 @@ import sangria.schema.{
   ObjectType,
   OptionType,
   StringType,
-  fields,
+  fields
 }
 import models.gql.Arguments.{studyTypes, pageArg, pageSize, variantIds}
 import models.gql.TypeWithId
@@ -39,7 +39,7 @@ case class Loci(
     count: Long,
     rows: Option[Seq[Locus]],
     id: String
-) extends TypeWithId 
+) extends TypeWithId
 
 object Loci extends Logging {
   import sangria.macros.derive._
@@ -62,7 +62,7 @@ object Loci extends Logging {
   )
 
   implicit val lociImp: ObjectType[Backend, Loci] = deriveObjectType[Backend, Loci](
-    ExcludeFields("id"),
+    ExcludeFields("id")
   )
   implicit val locusF: OFormat[Locus] = Json.format[Locus]
   implicit val lociR: Reads[Loci] = (

--- a/app/models/entities/Study.scala
+++ b/app/models/entities/Study.scala
@@ -20,6 +20,7 @@ import sangria.schema.{
   DeferredValue
 }
 import models.gql.StudyTypeEnum
+import models.gql.CredibleSetsByStudyDeferred
 import models.gql.Arguments.{pageArg, StudyType}
 import play.api.libs.json._
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
@@ -241,8 +242,10 @@ object Study extends Logging {
       description = Some("Credible sets"),
       resolve = js => {
         val studyId = (js.value \ "studyId").as[String]
-        val credSetQueryArgs = CredibleSetQueryArgs(studyIds = Seq(studyId))
-        js.ctx.getCredibleSets(credSetQueryArgs, js.arg(pageArg))
+        //val credSetQueryArgs = CredibleSetQueryArgs(studyIds = Seq(studyId))
+        //js.ctx.getCredibleSets(credSetQueryArgs, js.arg(pageArg))
+        CredibleSetsByStudyDeferred(studyId, js.arg(pageArg))
+
       }
     )
   lazy val studyImp: ObjectType[Backend, JsValue] = ObjectType(

--- a/app/models/gql/DeferredResolvers.scala
+++ b/app/models/gql/DeferredResolvers.scala
@@ -7,88 +7,92 @@ import scala.concurrent._
 import cats.syntax.group
 
 trait TypeWithId {
-    val id: String
+  val id: String
 }
 
 case class GroupedResults[T](grouping: Product, results: Future[IndexedSeq[T]])
 
 abstract class DeferredMultiTerm[+T]() extends Deferred[T] {
-    val id: String
-    val grouping: Product
-    def empty(): T
-    def resolver(ctx: Backend): (Seq[String], Product) => Future[IndexedSeq[T]]
+  val id: String
+  val grouping: Product
+  def empty(): T
+  def resolver(ctx: Backend): (Seq[String], Product) => Future[IndexedSeq[T]]
 }
 
-case class LocusDeferred(studyLocusId: String, variantIds: Option[Seq[String]], pagination: Option[Pagination]) extends DeferredMultiTerm[Loci] {
-    val id: String = studyLocusId
-    val grouping = (variantIds, pagination)
-    def empty(): Loci = Loci(0, None, "")
-    def resolver(ctx: Backend): (Seq[String], Product) => Future[IndexedSeq[Loci]] = {
-        case (s: Seq[String], options: Product) => {
-            options match {
-                case (v, p) =>
-                    ctx.getLocus(s, v.asInstanceOf[Option[Seq[String]]], p.asInstanceOf[Option[Pagination]])
-            }
-        }
-    }
+case class LocusDeferred(studyLocusId: String,
+                         variantIds: Option[Seq[String]],
+                         pagination: Option[Pagination]
+) extends DeferredMultiTerm[Loci] {
+  val id: String = studyLocusId
+  val grouping = (variantIds, pagination)
+  def empty(): Loci = Loci(0, None, "")
+  def resolver(ctx: Backend): (Seq[String], Product) => Future[IndexedSeq[Loci]] = {
+    case (s: Seq[String], options: Product) =>
+      options match {
+        case (v, p) =>
+          ctx.getLocus(s, v.asInstanceOf[Option[Seq[String]]], p.asInstanceOf[Option[Pagination]])
+      }
+  }
 }
-
 
 /** A deferred resolver for cases where we can't use the Fetch API because we resolve the
- * values on multiple terms/filters. 
- **/
+  * values on multiple terms/filters.
+  */
 class MultiTermResolver extends DeferredResolver[Backend] with Logging {
-    def groupResults[T](deferred: Vector[DeferredMultiTerm[T]], ctx: Backend): Map[Product, Future[IndexedSeq[T]]] = {
-        val grouped = deferred.groupBy(q => q.grouping)
-        val queries = grouped.map {
-            case (grouping, queries) =>
-                val ids = queries.map(_.id)
-                val resolver = queries.head.resolver(ctx)
-                (ids, grouping, resolver)
-            }
-        val results = queries.map {
-            case (ids, grouping, resolver) =>
-                val r = resolver(ids, grouping)
-                grouping -> r
-        }.toMap
-        results
+  def groupResults[T](deferred: Vector[DeferredMultiTerm[T]],
+                      ctx: Backend
+  ): Map[Product, Future[IndexedSeq[T]]] = {
+    val grouped = deferred.groupBy(q => q.grouping)
+    val queries = grouped.map { case (grouping, queries) =>
+      val ids = queries.map(_.id)
+      val resolver = queries.head.resolver(ctx)
+      (ids, grouping, resolver)
     }
+    val results = queries.map { case (ids, grouping, resolver) =>
+      val r = resolver(ids, grouping)
+      grouping -> r
+    }.toMap
+    results
+  }
 
-    def getResultForId[T](deferredQ: DeferredMultiTerm[T], results: Map[Product, Future[IndexedSeq[TypeWithId]]])(implicit ec: ExecutionContext): Future[T] = {
-        val group = results.get(deferredQ.grouping).get
-        val hit = group.map(_.filter(_.id == deferredQ.id))
-        hit.map(_.headOption.getOrElse(deferredQ.empty()).asInstanceOf[T])
-    }
+  def getResultForId[T](deferredQ: DeferredMultiTerm[T],
+                        results: Map[Product, Future[IndexedSeq[TypeWithId]]]
+  )(implicit ec: ExecutionContext): Future[T] = {
+    val group = results.get(deferredQ.grouping).get
+    val hit = group.map(_.filter(_.id == deferredQ.id))
+    hit.map(_.headOption.getOrElse(deferredQ.empty()).asInstanceOf[T])
+  }
 
-    def resolve(deferred: Vector[Deferred[Any]], ctx: Backend, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]] = {
-        val lq = deferred collect {case q: LocusDeferred => q}
-        val results = groupResults(lq, ctx)
-        deferred.map {
-            case q: LocusDeferred =>
-                getResultForId(q, results)
-        }
+  def resolve(deferred: Vector[Deferred[Any]], ctx: Backend, queryState: Any)(implicit
+      ec: ExecutionContext
+  ): Vector[Future[Any]] = {
+    val lq = deferred collect { case q: LocusDeferred => q }
+    val results = groupResults(lq, ctx)
+    deferred.map { case q: LocusDeferred =>
+      getResultForId(q, results)
     }
+  }
 }
 
 object DeferredResolvers extends Logging {
-    val multiTermResolver = new MultiTermResolver()
-    // add fetchers and locusResolver to the resolvers
-    val deferredResolvers: DeferredResolver[Backend] = DeferredResolver.fetchersWithFallback(
-        multiTermResolver,
-        Fetchers.biosamplesFetcher,
-        Fetchers.credibleSetFetcher,
-        Fetchers.l2gFetcher,
-        Fetchers.targetsFetcher,
-        Fetchers.drugsFetcher,
-        Fetchers.diseasesFetcher,
-        Fetchers.hposFetcher,
-        Fetchers.reactomeFetcher,
-        Fetchers.expressionFetcher,
-        Fetchers.otarProjectsFetcher,
-        Fetchers.soTermsFetcher,
-        Fetchers.indicationFetcher,
-        Fetchers.goFetcher,
-        Fetchers.variantFetcher,
-        Fetchers.gwasFetcher
-    ) 
+  val multiTermResolver = new MultiTermResolver()
+  // add fetchers and locusResolver to the resolvers
+  val deferredResolvers: DeferredResolver[Backend] = DeferredResolver.fetchersWithFallback(
+    multiTermResolver,
+    Fetchers.biosamplesFetcher,
+    Fetchers.credibleSetFetcher,
+    Fetchers.l2gFetcher,
+    Fetchers.targetsFetcher,
+    Fetchers.drugsFetcher,
+    Fetchers.diseasesFetcher,
+    Fetchers.hposFetcher,
+    Fetchers.reactomeFetcher,
+    Fetchers.expressionFetcher,
+    Fetchers.otarProjectsFetcher,
+    Fetchers.soTermsFetcher,
+    Fetchers.indicationFetcher,
+    Fetchers.goFetcher,
+    Fetchers.variantFetcher,
+    Fetchers.gwasFetcher
+  )
 }

--- a/app/models/gql/DeferredResolvers.scala
+++ b/app/models/gql/DeferredResolvers.scala
@@ -4,57 +4,91 @@ import models.{Backend, entities}
 import play.api.Logging
 import sangria.execution.deferred.{Deferred, DeferredResolver}
 import scala.concurrent._
+import cats.syntax.group
 
-case class LocusDeferred(studyLocusId: String,
-                         variantIds: Option[Seq[String]],
-                         pagination: Option[Pagination]
-) extends Deferred[Loci]
+trait TypeWithId {
+    val id: String
+}
 
-// TODO: Genericize this resolver to handle not just locus but other deferred types: hint - use the groupDeferred method
-class LocusResolver extends DeferredResolver[Backend] with Logging {
-  def resolve(deferred: Vector[Deferred[Any]], ctx: Backend, queryState: Any)(implicit
-      ec: ExecutionContext
-  ): Vector[Future[Any]] = {
-    val lq = deferred collect { case q: LocusDeferred => q }
-    // group by variantIds and pagination so that we can use studyLocusId to fetch the loci
-    val groupedLq = lq.groupBy(q => (q.variantIds, q.pagination))
-    val locusQueries = groupedLq.map { case ((variantIds, pagination), queries) =>
-      val studyLocusIds = queries.map(_.studyLocusId)
-      (studyLocusIds, variantIds, pagination)
+case class GroupedResults[T](grouping: Product, results: Future[IndexedSeq[T]])
+
+abstract class DeferredMultiTerm[+T]() extends Deferred[T] {
+    val id: String
+    val grouping: Product
+    def empty(): T
+    def resolver(ctx: Backend): (Seq[String], Product) => Future[IndexedSeq[T]]
+}
+
+case class LocusDeferred(studyLocusId: String, variantIds: Option[Seq[String]], pagination: Option[Pagination]) extends DeferredMultiTerm[Loci] {
+    val id: String = studyLocusId
+    val grouping = (variantIds, pagination)
+    def empty(): Loci = Loci(0, None, "")
+    def resolver(ctx: Backend): (Seq[String], Product) => Future[IndexedSeq[Loci]] = {
+        case (s: Seq[String], options: Product) => {
+            options match {
+                case (v, p) =>
+                    ctx.getLocus(s, v.asInstanceOf[Option[Seq[String]]], p.asInstanceOf[Option[Pagination]])
+            }
+        }
     }
-    // results grouped by variantIds and pagination
-    val results = locusQueries.map { case (studyLocusIds, variantIds, pagination) =>
-      val r = ctx.getLocus(studyLocusIds, variantIds, pagination)
-      (variantIds, pagination) -> r
-    }.toMap
-    deferred.map { case LocusDeferred(studyLocusId, variantIds, pagination) =>
-      // lookup results based on the variantIds pagination group in the results
-      val group = results.get((variantIds, pagination)).get
-      val l = group.map(loci => loci.filter(studyLocusId == _.studyLocusId))
-      l.map(_.headOption.getOrElse(Loci.empty()))
+}
+
+
+/** A deferred resolver for cases where we can't use the Fetch API because we resolve the
+ * values on multiple terms/filters. 
+ **/
+class MultiTermResolver extends DeferredResolver[Backend] with Logging {
+    def groupResults[T](deferred: Vector[DeferredMultiTerm[T]], ctx: Backend): Map[Product, Future[IndexedSeq[T]]] = {
+        val grouped = deferred.groupBy(q => q.grouping)
+        val queries = grouped.map {
+            case (grouping, queries) =>
+                val ids = queries.map(_.id)
+                val resolver = queries.head.resolver(ctx)
+                (ids, grouping, resolver)
+            }
+        val results = queries.map {
+            case (ids, grouping, resolver) =>
+                val r = resolver(ids, grouping)
+                grouping -> r
+        }.toMap
+        results
     }
-  }
+
+    def getResultForId[T](deferredQ: DeferredMultiTerm[T], results: Map[Product, Future[IndexedSeq[TypeWithId]]])(implicit ec: ExecutionContext): Future[T] = {
+        val group = results.get(deferredQ.grouping).get
+        val hit = group.map(_.filter(_.id == deferredQ.id))
+        hit.map(_.headOption.getOrElse(deferredQ.empty()).asInstanceOf[T])
+    }
+
+    def resolve(deferred: Vector[Deferred[Any]], ctx: Backend, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]] = {
+        val lq = deferred collect {case q: LocusDeferred => q}
+        val results = groupResults(lq, ctx)
+        deferred.map {
+            case q: LocusDeferred =>
+                getResultForId(q, results)
+        }
+    }
 }
 
 object DeferredResolvers extends Logging {
-  val locusResolver = new LocusResolver()
-  // add fetchers and locusResolver to the resolvers
-  val deferredResolvers: DeferredResolver[Backend] = DeferredResolver.fetchersWithFallback(
-    locusResolver,
-    Fetchers.biosamplesFetcher,
-    Fetchers.credibleSetFetcher,
-    Fetchers.l2gFetcher,
-    Fetchers.targetsFetcher,
-    Fetchers.drugsFetcher,
-    Fetchers.diseasesFetcher,
-    Fetchers.hposFetcher,
-    Fetchers.reactomeFetcher,
-    Fetchers.expressionFetcher,
-    Fetchers.otarProjectsFetcher,
-    Fetchers.soTermsFetcher,
-    Fetchers.indicationFetcher,
-    Fetchers.goFetcher,
-    Fetchers.variantFetcher,
-    Fetchers.studyFetcher
-  )
+    val multiTermResolver = new MultiTermResolver()
+    // add fetchers and locusResolver to the resolvers
+    val deferredResolvers: DeferredResolver[Backend] = DeferredResolver.fetchersWithFallback(
+        multiTermResolver,
+        Fetchers.biosamplesFetcher,
+        Fetchers.credibleSetFetcher,
+        Fetchers.l2gFetcher,
+        Fetchers.targetsFetcher,
+        Fetchers.drugsFetcher,
+        Fetchers.diseasesFetcher,
+        Fetchers.hposFetcher,
+        Fetchers.reactomeFetcher,
+        Fetchers.expressionFetcher,
+        Fetchers.otarProjectsFetcher,
+        Fetchers.soTermsFetcher,
+        Fetchers.indicationFetcher,
+        Fetchers.goFetcher,
+        Fetchers.variantFetcher,
+        Fetchers.gwasFetcher
+    ) 
 }

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1351,7 +1351,6 @@ object Objects extends Logging {
           resolve = r => {
             val studyLocusId = r.value.otherStudyLocusId.getOrElse("")
             logger.debug(s"Finding colocalisation credible set: $studyLocusId")
-            // r.ctx.getCredibleSet(studyLocusId)
             credibleSetFetcher.deferOpt(studyLocusId)
           }
         )
@@ -1383,11 +1382,7 @@ object Objects extends Logging {
           description = Some("Credible sets"),
           arguments = pageArg :: studyTypes :: Nil,
           resolve = r => {
-            val studyTypesSeq = r.arg(studyTypes).getOrElse(Seq.empty)
-            val variantIdSeq = Seq(r.value.variantId)
-            val credSetQueryArgs =
-              CredibleSetQueryArgs(variantIds = variantIdSeq, studyTypes = studyTypesSeq)
-            r.ctx.getCredibleSets(credSetQueryArgs, r.arg(pageArg))
+            CredibleSetsByVariantDeferred(r.value.variantId, r.arg(studyTypes), r.arg(pageArg))
           }
         ),
         Field(

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1350,7 +1350,7 @@ object Objects extends Logging {
           Some("Credible set"),
           resolve = r => {
             val studyLocusId = r.value.otherStudyLocusId.getOrElse("")
-            logger.info(s"Finding colocalisation credible set: $studyLocusId")
+            logger.debug(s"Finding colocalisation credible set: $studyLocusId")
             // r.ctx.getCredibleSet(studyLocusId)
             credibleSetFetcher.deferOpt(studyLocusId)
           }


### PR DESCRIPTION
- resolves opentargets/issues#3642
- add generic deferred resolver for types with multiple filters/args (one/many-to-many)
- add deferred resolvers for credible sets by variant and study
- add ResultHandler for handling existing results, multi search results (new) and nested query results (new)