### PR TITLE
3663 count and rows for l2g predictions

### DIFF
--- a/app/models/entities/CredibleSet.scala
+++ b/app/models/entities/CredibleSet.scala
@@ -107,17 +107,8 @@ object CredibleSet extends Logging {
       description = None,
       arguments = pageArg :: Nil,
       resolve = js => {
-        //import scala.concurrent.ExecutionContext.Implicits.global
         val id: String = (js.value \ "studyLocusId").as[String]
         L2GPredictionsDeferred(id, js.arg(pageArg))
-        // val l2gValues = DeferredValue(l2gFetcher.deferRelSeq(l2gByStudyLocusIdRel, id))
-        // val t = js.arg(pageSize) match {
-        //   case Some(size) =>
-        //     l2gValues.map(_.take(size))
-        //   case None =>
-        //     l2gValues
-        // }
-        // t
       }
     ),
     Field(

--- a/app/models/entities/CredibleSet.scala
+++ b/app/models/entities/CredibleSet.scala
@@ -5,21 +5,16 @@ import models.gql.StudyTypeEnum
 import models.gql.Arguments.StudyType
 import models.entities.Study.{studyImp, studyWithoutCredSetsImp}
 import models.entities.Loci.lociImp
-import models.gql.Fetchers.{
-  studyFetcher,
-  l2gFetcher,
-  l2gByStudyLocusIdRel,
-  targetsFetcher,
-  variantFetcher
-}
+import models.gql.Fetchers.{studyFetcher, targetsFetcher, variantFetcher}
 import models.gql.ColocalisationsDeferred
 import models.gql.LocusDeferred
+import models.gql.L2GPredictionsDeferred
 import models.gql.Objects.{
   logger,
   targetImp,
   variantIndexImp,
   colocalisationsImp,
-  l2gPredictionsImp
+  l2GPredictionsImp
 }
 import play.api.Logging
 import play.api.libs.json._
@@ -107,21 +102,22 @@ object CredibleSet extends Logging {
       }
     ),
     Field(
-      "l2Gpredictions",
-      OptionType(ListType(l2gPredictionsImp)),
+      "l2GPredictions",
+      l2GPredictionsImp,
       description = None,
-      arguments = pageSize :: Nil,
+      arguments = pageArg :: Nil,
       resolve = js => {
-        import scala.concurrent.ExecutionContext.Implicits.global
+        //import scala.concurrent.ExecutionContext.Implicits.global
         val id: String = (js.value \ "studyLocusId").as[String]
-        val l2gValues = DeferredValue(l2gFetcher.deferRelSeq(l2gByStudyLocusIdRel, id))
-        val t = js.arg(pageSize) match {
-          case Some(size) =>
-            l2gValues.map(_.take(size))
-          case None =>
-            l2gValues
-        }
-        t
+        L2GPredictionsDeferred(id, js.arg(pageArg))
+        // val l2gValues = DeferredValue(l2gFetcher.deferRelSeq(l2gByStudyLocusIdRel, id))
+        // val t = js.arg(pageSize) match {
+        //   case Some(size) =>
+        //     l2gValues.map(_.take(size))
+        //   case None =>
+        //     l2gValues
+        // }
+        // t
       }
     ),
     Field(

--- a/app/models/entities/L2GPredictions.scala
+++ b/app/models/entities/L2GPredictions.scala
@@ -2,8 +2,9 @@ package models.entities
 
 import play.api.Logging
 import play.api.libs.json._
+import models.gql.TypeWithId
 
-case class L2GPredictions(
+case class L2GPrediction(
     studyLocusId: String,
     geneId: String,
     score: Double,
@@ -12,7 +13,17 @@ case class L2GPredictions(
 
 case class L2GFeature(key: String, value: Double)
 
-object L2GPredictions extends Logging {
+object L2GPrediction extends Logging {
   implicit val l2GFeatureF: OFormat[L2GFeature] = Json.format[L2GFeature]
-  implicit val l2GPredictionsF: OFormat[L2GPredictions] = Json.format[L2GPredictions]
+  implicit val l2GPredictionF: OFormat[L2GPrediction] = Json.format[L2GPrediction]
+}
+
+case class L2GPredictions(
+    count: Long,
+    rows: IndexedSeq[L2GPrediction],
+    id: String = ""
+) extends TypeWithId
+
+object L2GPredictions {
+  def empty: L2GPredictions = L2GPredictions(0, IndexedSeq.empty)
 }

--- a/app/models/entities/VariantIndex.scala
+++ b/app/models/entities/VariantIndex.scala
@@ -7,7 +7,8 @@ case class InSilicoPredictor(method: Option[String],
                              assessment: Option[String],
                              score: Option[Double],
                              assessmentFlag: Option[String],
-                             targetId: Option[String]
+                             targetId: Option[String],
+                             normalisedScore: Option[Double],
 )
 
 case class TranscriptConsequence(variantFunctionalConsequenceIds: Option[Seq[String]],

--- a/app/models/entities/VariantIndex.scala
+++ b/app/models/entities/VariantIndex.scala
@@ -42,7 +42,7 @@ case class VariantIndex(variantId: String,
                         rsIds: Option[Seq[String]],
                         dbXrefs: Option[Seq[DbXref]],
                         alleleFrequencies: Option[Seq[AlleleFrequency]],
-                        hgvsId: String,
+                        hgvsId: Option[String],
                         variantDescription: String
 )
 

--- a/app/models/gql/Fetchers.scala
+++ b/app/models/gql/Fetchers.scala
@@ -153,8 +153,6 @@ object Fetchers extends Logging {
   )
 
   val credibleSetFetcherCache = FetcherCache.simple
-  // val credibleSetByStudyRel =
-  //   Relation[JsValue, String]("byStudy", js => Seq((js \ "studyId").as[String]))
   val credibleSetFetcher: Fetcher[Backend, JsValue, JsValue, String] = {
     implicit val credibleSetFetcherId: HasId[JsValue, String] =
       HasId[JsValue, String](js => (js \ "studyLocusId").as[String])
@@ -163,29 +161,8 @@ object Fetchers extends Logging {
         .maxBatchSize(entities.Configuration.batchSize)
         .caching(credibleSetFetcherCache),
       fetch = (ctx: Backend, ids: Seq[String]) => ctx.getCredibleSet(ids)
-      // },
-      // fetchRel = (ctx: Backend, ids: RelationIds[JsValue]) => {
-      //   ctx.getCredibleSets(entities.CredibleSetQueryArgs(studyIds = ids(credibleSetByStudyRel)),
-      //                       Some(Pagination.mkMax)
-      //   )
-      // }
     )
   }
-
-  val l2gFetcherCache = FetcherCache.simple
-  implicit val l2gHasId: HasId[L2GPredictions, String] =
-    HasId[L2GPredictions, String](_.studyLocusId)
-  val l2gByStudyLocusIdRel =
-    Relation[L2GPredictions, String]("byStudyLocus", l2g => Seq(l2g.studyLocusId))
-  val l2gFetcher: Fetcher[Backend, L2GPredictions, L2GPredictions, String] = Fetcher.rel(
-    config = FetcherConfig.maxBatchSize(entities.Configuration.batchSize).caching(l2gFetcherCache),
-    fetch = (ctx: Backend, ids: Seq[String]) => {
-      ctx.getL2GPredictions(ids)
-    },
-    fetchRel = (ctx: Backend, ids: RelationIds[L2GPredictions]) => {
-      ctx.getL2GPredictions(ids(l2gByStudyLocusIdRel))
-    }
-  )
 
   val studyFetcherCache = FetcherCache.simple
   val studyFetcher: Fetcher[Backend, JsValue, JsValue, String] = {
@@ -225,7 +202,6 @@ object Fetchers extends Logging {
       hpoFetcherCache,
       goFetcherCache,
       variantFetcherCache,
-      l2gFetcherCache,
       targetsFetcherCache,
       drugsFetcherCache,
       diseasesFetcherCache,

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1326,10 +1326,10 @@ object Objects extends Logging {
   implicit val alleleFrequencyImp: ObjectType[Backend, AlleleFrequency] =
     deriveObjectType[Backend, AlleleFrequency]()
   implicit val biosampleImp: ObjectType[Backend, Biosample] = deriveObjectType[Backend, Biosample]()
-  implicit val l2gFeatureImp: ObjectType[Backend, L2GFeature] =
+  implicit val l2GFeatureImp: ObjectType[Backend, L2GFeature] =
     deriveObjectType[Backend, L2GFeature]()
-  implicit val l2gPredictionsImp: ObjectType[Backend, L2GPredictions] =
-    deriveObjectType[Backend, L2GPredictions](
+  implicit val l2GPredictionImp: ObjectType[Backend, L2GPrediction] =
+    deriveObjectType[Backend, L2GPrediction](
       ReplaceField(
         "geneId",
         Field(
@@ -1340,6 +1340,8 @@ object Objects extends Logging {
         )
       )
     )
+  implicit val l2GPredictionsImp: ObjectType[Backend, L2GPredictions] =
+    deriveObjectType[Backend, L2GPredictions]()
   implicit val colocalisationImp: ObjectType[Backend, Colocalisation] =
     deriveObjectType[Backend, Colocalisation](
       ReplaceField(


### PR DESCRIPTION
- resolves opentargets/issues#3663
- add pagination (replaces `size`) to L2G predictions 
- field name from `l2Gpredictions` to `l2GPredictions`
- add count and rows to `l2GPredictions`
- `variant.hgvsId` now nullable
- add `normalisedScore` to `InSilicoPredictor`