### PR TITLE
make the niceName optional

### DIFF
--- a/app/models/entities/Evidence.scala
+++ b/app/models/entities/Evidence.scala
@@ -31,7 +31,7 @@ case class EvidenceVariation(
 
 case class LabelledElement(id: String, label: String)
 
-case class LabelledUri(url: String, niceName: String)
+case class LabelledUri(url: String, niceName: Option[String])
 
 case class BiomarkerGeneExpression(name: Option[String], id: Option[String])
 


### PR DESCRIPTION
This PR makes the niceName in the urls list of Evidence optional to solve a bug with the entity definition.

Closes opentargets/issues#3797.