### PR TITLE
3741 update lit query

### DIFF
--- a/app/esecuele/QuerySection.scala
+++ b/app/esecuele/QuerySection.scala
@@ -5,9 +5,10 @@ abstract class QuerySection extends Rep {
   val content: Seq[Column]
 }
 
-case class With(content: Seq[Column]) extends QuerySection {
+case class With(content: Seq[Column], alias: Option[String | Column] = None) extends QuerySection {
   override val name: String = "WITH"
-  override val rep: String = s"$name ${content.mkString("", ", ", "")}"
+  override val rep: String =
+    s"$name${alias.map(" " + _ + " as").getOrElse("")} ${content.mkString("", ", ", "")}"
 }
 
 case class Select(content: Seq[Column]) extends QuerySection {

--- a/app/models/db/QLITAGG.scala
+++ b/app/models/db/QLITAGG.scala
@@ -113,23 +113,26 @@ case class QLITAGG(
       )
     )
   )
-
+  /**
+   * with cte_pmids  as (SELECT pmid FROM ot.literature_index PREWHERE (in(keywordId,('ENSG00000133703'))) GROUP BY pmid HAVING (greaterOrEquals(count(pmid),1)) ORDER BY sum(relevance) DESC, any(date) DESC) SELECT pmid, pmcid, date, year, month FROM cte_pmids l INNER JOIN (select * from ot.literature PREWHERE(in(pmid, (select pmid from cte_pmids)))) r USING (pmid) LIMIT 25 OFFSET 0
+   * **/
+//TDDO: implement with cte_pmids  as (SELECT pmid FROM ot.literature_index PREWHERE (in(keywordId,('ENSG00000133703'))) GROUP BY pmid HAVING (greaterOrEquals(count(pmid),1)) ORDER BY sum(relevance) DESC, any(date) DESC) SELECT pmid, pmcid, date, year, month FROM cte_pmids l INNER JOIN (select * from ot.literature PREWHERE(in(pmid, (select pmid from cte_pmids)))) r USING (pmid) LIMIT 25 OFFSET 0
   override val query: Q = {
 
     val q = filterDate match {
       case Some(value) =>
         Q(
           Select(pmid :: pmcid :: date :: year :: month :: Nil),
-          From(T),
-          PreWhere(F.in(pmid, pmidsQ(pmid :: Nil).toColumn(None))),
+          From(pmidsQ(pmid :: Nil).toColumn(None), Some("l")),
+          Join(T, None, Some("INNER"), false, Some("r"), pmid :: Nil),
           dateFilter(value),
           Limit(offset, size)
         )
       case _ =>
         Q(
           Select(pmid :: pmcid :: date :: year :: month :: Nil),
-          From(T),
-          PreWhere(F.in(pmid, pmidsQ(pmid :: Nil).toColumn(None))),
+          From(pmidsQ(pmid :: Nil).toColumn(None), Some("l")),
+          Join(T, None, Some("INNER"), false, Some("r"), pmid :: Nil),
           Limit(offset, size)
         )
     }


### PR DESCRIPTION
- **update to join and add comment to new query**
- **update query to maintain the order**

This Item solves [3741](https://github.com/opentargets/issues/issues/3741). It's solved by moving the ordering query outside the the sub query to an inner join.