### PR TITLE
update date filter to enable both ends of the filter

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -1036,13 +1036,26 @@ class Backend @Inject() (implicit
 
     val pag = Helpers.Cursor.to(cursor).flatMap(_.asOpt[Pagination]).getOrElse(Pagination.mkDefault)
 
-    val filterDate = (startYear, endYear) match {
-      case (Some(strYear), Some(ndYear)) =>
-        Some(strYear, startMonth.getOrElse(1), ndYear, endMonth.getOrElse(12))
+    val filterStartDate = startYear match {
+      case Some(strYear) =>
+        Some(strYear, startMonth.getOrElse(1))
       case _ => Option.empty
     }
 
-    val simQ = QLITAGG(table.name, indexTable.name, ids, pag.size, pag.offset, filterDate)
+    val filterEndDate = endYear match {
+      case Some(ndYear) =>
+        Some(ndYear, endMonth.getOrElse(12))
+      case _ => Option.empty
+    }
+
+    val simQ = QLITAGG(table.name,
+                       indexTable.name,
+                       ids,
+                       pag.size,
+                       pag.offset,
+                       filterStartDate,
+                       filterEndDate
+    )
 
     def runQuery(year: Int, total: Long) =
       dbRetriever.executeQuery[Publication, Query](simQ.query).map { v =>

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -124,9 +124,11 @@ object Arguments {
              description = "Year at the lower end of the filter"
     )
   val startMonth: Argument[Option[Int]] =
-    Argument("startMonth",
-             OptionInputType(IntType),
-             description = "Month at the lower end of the filter"
+    Argument(
+      "startMonth",
+      OptionInputType(IntType),
+      description =
+        "Month at the lower end of the filter. This value will be ignored if startYear is not set"
     )
   val endYear: Argument[Option[Int]] =
     Argument("endYear",
@@ -134,9 +136,11 @@ object Arguments {
              description = "Year at the higher end of the filter"
     )
   val endMonth: Argument[Option[Int]] =
-    Argument("endMonth",
-             OptionInputType(IntType),
-             description = "Month at the higher end of the filter"
+    Argument(
+      "endMonth",
+      OptionInputType(IntType),
+      description =
+        "Month at the higher end of the filter. This value will be ignored if endYear is not set"
     )
 
   val BFilterString: Argument[Option[String]] = Argument(


### PR DESCRIPTION
This item solves the issue [3861](https://github.com/opentargets/issues/issues/3861) by splitting the date filter in two and handling two additional cases where only either the start or end dates are set. Also expands the description of the month arguments.