### PR TITLE
Add resolved ancestors to Disease

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,6 @@ run: ## Runs API
 debug: ## Debugs API
 	@sbt -jvm-debug 9999 run
 
-debug_with_standalone: ## Debugs API
-	@sbt -jvm-debug 9999 "run 8090" -DPLATFORM_API_IGNORE_CACHE=true
-
 run_log: ## Runs API using the logback file specified in logfile eg: make run_log logfile=./conf/logback.xml
 	@sbt run -Dlogback.configurationFile=${logfile}
 
@@ -25,13 +22,13 @@ debug_log: ## Debugs API using the logback file specified in logfile eg: make de
 debug_log_standalone: ## Debugs API using the logback file specified in logfile eg: make debug_log_standalone logfile=./conf/logback.xml
 	@sbt -jvm-debug 9999 "run 8090" -Dlogback.configurationFile=${logfile}
 
-es_tunnel: ## Create tunnel connection to ElasticSearch eg make es_tunnel zone europe-west1-d instance trnplt-es-0-esearch-fl6c
-	@echo "Connecting to ElasticSearch"
-	@gcloud compute ssh --zone "${zone}" ${instance} --tunnel-through-iap -- -L 9200:localhost:9200
+es_tunnel: ## Create tunnel connection to OpenSearch. E.g.: make es_tunnel zone=europe-west1-d instance=trnplt-es-0-esearch-fl6c
+	@echo "Connecting to OpenSearch"
+	@gcloud compute ssh --zone "${zone}" --tunnel-through-iap ${instance} -- -L 9200:localhost:9200 -N
 
-ch_tunnel: ## Create tunnel connection to Clickhouse eg. make ch_tunnel zone europe-west1-d instance trnplt-es-0-esearch-fl6c
-	@echo "Connecting to Clickhouse"
-	@gcloud compute ssh ${instance} --zone="${zone}" --tunnel-through-iap -- -L 8123:localhost:8123
+ch_tunnel: ## Create tunnel connection to ClickHouse. E.g.: make ch_tunnel zone=europe-west1-d instance=trnplt-es-0-esearch-fl6c
+	@echo "Connecting to ClickHouse"
+	@gcloud compute ssh --zone "${zone}" --tunnel-through-iap ${instance} -- -L 8123:localhost:8123 -N
 
 run_with_standalone: ## Runs API with standalone platform
 	@sbt "run 8090" -J-Xms2g -J-Xmx7g -J-XX:+UseG1GC -DPLATFORM_API_IGNORE_CACHE=true -DELASTICSEARCH_HOST=elasticsearch -DSLICK_CLICKHOUSE_URL=jdbc:clickhouse://clickhouse:8123

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -458,6 +458,16 @@ object Objects extends Logging {
             }),
             ctx arg pageArg
           )
+      ),
+      Field(
+        "resolvedAncestors",
+        ListType(diseaseImp),
+        description = Some(
+          "All parent diseases in the hierarchy from the term up to a " +
+            "therapeutic area."
+        ),
+        arguments = Nil,
+        resolve = ctx => diseasesFetcher.deferSeq(ctx.value.ancestors)
       )
     )
   )


### PR DESCRIPTION
This PR adds a field with resolved ancestors into the Disease schema. That way, we can get the whole set of diseases needed to draw the Ontology graph in the frontend.

Also, I've improved the `make {es_tunnel,ch_tunnel}` commands to create them in the background and avoid locking the terminal.