### PR TITLE
Cast `ELASTICSEARCH_PORT` env var into Integer

### DIFF
--- a/app/models/entities/Configuration.scala
+++ b/app/models/entities/Configuration.scala
@@ -80,8 +80,13 @@ object Configuration {
   implicit val metaJSONImp: OFormat[Meta] = Json.format[Meta]
 
   implicit val esEntitiesJSONImp: OFormat[ElasticsearchEntity] = Json.format[ElasticsearchEntity]
-  implicit val esSettingsJSONImp: OFormat[ElasticsearchSettings] =
-    Json.format[ElasticsearchSettings]
+  implicit val esSettingsJSONImp: Reads[ElasticsearchSettings] = ((__ \ "host").read[String] and
+    (__ \ "port").read[String].map(_.toInt).orElse((__ \ "port").read[Int]) and
+    (__ \ "entities").read[Seq[ElasticsearchEntity]] and
+    (__ \ "highlightFields").read[Seq[String]])(ElasticsearchSettings.apply)
+
+  implicit val esSettingsJSONWrites: OWrites[ElasticsearchSettings] =
+    Json.writes[ElasticsearchSettings]
 
   implicit val luTableJSONImp: OFormat[LUTableSettings] = Json.format[LUTableSettings]
   implicit val dbTableSettingsImp: OFormat[DbTableSettings] =


### PR DESCRIPTION
When passing the env var `ELASTICSEARCH_PORT`, API crashes. The `ElasticsearchSettings` type expects an Int and env vars are always Strings.

This PR fixes that.