### PR TITLE
3892 resolve credsets by target

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "scala",
+            "request": "attach",
+            "name": "Play",
+            "buildTarget": "root",
+            "hostName": "localhost",
+            "port": 5005
+        }
+
+    ]
+}

--- a/app/clickhouse/rep/SeqRep.scala
+++ b/app/clickhouse/rep/SeqRep.scala
@@ -65,15 +65,6 @@ object SeqRep {
         Vector.empty
   }
 
-  abstract class StringParser[T](str: String) {
-    protected val tokens: Array[String] = str.split(",")
-
-    protected def optionalValue[A](token: String)(f: String => A): Option[A] =
-      if (token.isEmpty) None else Some(f(token))
-
-    def parse: T
-  }
-
   object Implicits {
     implicit def seqInt(from: ISeqRep): Vector[Int] = from.rep
     implicit def seqLong(from: LSeqRep): Vector[Long] = from.rep

--- a/app/clickhouse/rep/SeqRep.scala
+++ b/app/clickhouse/rep/SeqRep.scala
@@ -65,6 +65,15 @@ object SeqRep {
         Vector.empty
   }
 
+  abstract class StringParser[T](str: String) {
+    protected val tokens: Array[String] = str.split(",")
+
+    protected def optionalValue[A](token: String)(f: String => A): Option[A] =
+      if (token.isEmpty) None else Some(f(token))
+
+    def parse: T
+  }
+
   object Implicits {
     implicit def seqInt(from: ISeqRep): Vector[Int] = from.rep
     implicit def seqLong(from: LSeqRep): Vector[Long] = from.rep

--- a/app/esecuele/QuerySection.scala
+++ b/app/esecuele/QuerySection.scala
@@ -71,6 +71,15 @@ case class Format(format: String) extends QuerySection {
   override val rep: String = s"$name $format"
 }
 
+case class Settings(settings: Map[String, String] = Map.empty) extends QuerySection {
+  override val content: Seq[Column] = Nil
+  override val name: String = "SETTINGS"
+  override val rep: String =
+    if (settings.nonEmpty)
+      s"$name ${settings.map { case (k, v) => s"$k=$v" }.mkString(", ")}"
+    else ""
+}
+
 case class From(col: Column, alias: Option[String] = None) extends QuerySection {
   override val content: Seq[Column] = Seq(col)
   override val name: String = "FROM"

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -11,7 +11,7 @@ import gql.validators.QueryTermsValidator.*
 
 import javax.inject.Inject
 import models.Helpers.*
-import models.db.{QAOTF, QLITAGG, QW2V, IntervalsQuery}
+import models.db.{QAOTF, QLITAGG, QW2V, IntervalsQuery, TargetsQuery}
 import models.entities.Publication.*
 import models.entities.Associations.*
 import models.entities.Biosample.*
@@ -781,9 +781,12 @@ class Backend @Inject() (implicit
   }
 
   def getTargets(ids: Seq[String]): Future[IndexedSeq[Target]] = {
-    val targetIndexName = getIndexOrDefault("target", Some("targets"))
-
-    esRetriever.getByIds(targetIndexName, ids, fromJsValue[Target])
+    val tableName = defaultOTSettings.clickhouse.target.name
+    val targetsQuery = TargetsQuery(ids, tableName, 0, Pagination.sizeMax)
+    val results = dbRetriever
+      .executeQuery[Target, Query](targetsQuery.query)
+      .map(targets => targets)
+    results
   }
 
   def getSoTerms(ids: Seq[String]): Future[IndexedSeq[SequenceOntologyTerm]] = {

--- a/app/models/db/IntervalsQuery.scala
+++ b/app/models/db/IntervalsQuery.scala
@@ -4,7 +4,6 @@ import esecuele.Column.column
 import esecuele.Column.literal
 import esecuele._
 import play.api.Logging
-import com.sksamuel.elastic4s.requests.common.Operator.Or
 
 case class IntervalsQuery(chromosome: String,
                           start: Int,

--- a/app/models/db/TargetsQuery.scala
+++ b/app/models/db/TargetsQuery.scala
@@ -1,0 +1,27 @@
+package models.db
+
+import esecuele.Column.column
+import esecuele.Column.literal
+import esecuele._
+import play.api.Logging
+
+case class TargetsQuery(ids: Seq[String], tableName: String, offset: Int, size: Int)
+    extends Queryable
+    with Logging {
+
+  private val conditional = Where(
+    Functions.in(column("id"), Functions.set(ids.map(literal).toSeq))
+  )
+
+  override val query: Query =
+    Query(
+      Select(
+        Column.star :: Nil
+      ),
+      From(column(tableName)),
+      conditional,
+      OrderBy(column("id") :: Nil),
+      Limit(offset, size),
+      Format("JSONEachRow")
+    )
+}

--- a/app/models/db/TargetsQuery.scala
+++ b/app/models/db/TargetsQuery.scala
@@ -22,6 +22,7 @@ case class TargetsQuery(ids: Seq[String], tableName: String, offset: Int, size: 
       conditional,
       OrderBy(column("id") :: Nil),
       Limit(offset, size),
-      Format("JSONEachRow")
+      Format("JSONEachRow"),
+      Settings(Map("output_format_json_escape_forward_slashes" -> "0"))
     )
 }

--- a/app/models/entities/Configuration.scala
+++ b/app/models/entities/Configuration.scala
@@ -37,7 +37,7 @@ object Configuration {
 
   case class DbTableSettings(label: String, name: String)
 
-  case class TargetSettings(associations: DbTableSettings)
+  case class TargetSettings(label: String, name: String, associations: DbTableSettings)
 
   case class DiseaseSettings(associations: DbTableSettings)
 

--- a/app/models/entities/Target.scala
+++ b/app/models/entities/Target.scala
@@ -1,9 +1,14 @@
 package models.entities
 
+import clickhouse.rep.SeqRep._
 import play.api.Logging
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json._
+import slick.jdbc.GetResult
+import models.gql.Arguments.studyIds
+import org.checkerframework.checker.units.qual.g
+import org.checkerframework.checker.units.qual.t
 
 case class ChemicalProbeUrl(niceName: String, url: Option[String])
 
@@ -117,26 +122,27 @@ case class ReactomePathway(pathway: String, pathwayId: String, topLevelTerm: Str
 case class Target(
     id: String,
     alternativeGenes: Seq[String] = Seq.empty,
-    approvedSymbol: String,
     approvedName: String,
+    approvedSymbol: String,
     biotype: String,
     chemicalProbes: Seq[ChemicalProbe] = Seq.empty,
+    constraint: Seq[Constraint] = Seq.empty,
     dbXrefs: Seq[IdAndSource] = Seq.empty,
     functionDescriptions: Seq[String] = Seq.empty,
-    constraint: Seq[Constraint] = Seq.empty,
     genomicLocation: GenomicLocation,
     go: Seq[GeneOntology] = Seq.empty,
     hallmarks: Option[Hallmarks],
     homologues: Seq[Homologue] = Seq.empty,
+    nameSynonyms: Seq[LabelAndSource] = Seq.empty,
+    obsoleteNames: Seq[LabelAndSource] = Seq.empty,
+    obsoleteSymbols: Seq[LabelAndSource] = Seq.empty,
     pathways: Seq[ReactomePathway] = Seq.empty,
     proteinIds: Seq[IdAndSource] = Seq.empty,
     safetyLiabilities: Seq[SafetyLiability] = Seq.empty,
+    studyIds: Seq[String] = Seq.empty,
     subcellularLocations: Seq[LocationAndSource] = Seq.empty,
-    synonyms: Seq[LabelAndSource] = Seq.empty, // double check, this is name and symbol
     symbolSynonyms: Seq[LabelAndSource] = Seq.empty,
-    nameSynonyms: Seq[LabelAndSource] = Seq.empty,
-    obsoleteSymbols: Seq[LabelAndSource] = Seq.empty,
-    obsoleteNames: Seq[LabelAndSource] = Seq.empty,
+    synonyms: Seq[LabelAndSource] = Seq.empty, // double check, this is name and symbol
     targetClass: Seq[TargetClass] = Seq.empty,
     tep: Option[Tep],
     tractability: Seq[Tractability] = Seq.empty,
@@ -145,34 +151,148 @@ case class Target(
 
 object Target extends Logging {
 
-  implicit val cancerHallmarkImpW: OWrites[CancerHallmark] = Json.writes[CancerHallmark]
-  implicit val cancerHallmarkImpR: Reads[CancerHallmark] =
-    ((__ \ "description").read[String] and
-      (__ \ "impact").readNullable[String] and
-      (__ \ "label").read[String] and
-      (__ \ "pmid").read[Long])(CancerHallmark.apply)
+  implicit val getTargetFromDB: GetResult[Target] =
+    GetResult { r =>
+      // val id: String = r.<<
+      // val alternativeGenes: String = r.<<
+      // val approvedName: String = r.<<
+      // val approvedSymbol: String = r.<<
+      // val biotype: String = r.<<
+      // val chemicalProbes: String = r.<<
+      // val constraint: String = r.<<
+      // val dbXrefs: String = r.<<
+      // val functionDescriptions: String = r.<<
+      // val genomicLocation: String = r.<<
+      // val go: String = r.<<
+      // val hallmarks: String = r.<<?
+      // val homologues: String = r.<<
+      // val nameSynonyms: String = r.<<
+      // val obsoleteNames: String = r.<<
+      // val obsoleteSymbols: String = r.<<
+      // val pathways: String = r.<<
+      // val proteinIds: String = r.<<
+      // val safetyLiabilities: String = r.<<
+      // val studyIds: String = r.<<
+      // val subcellularLocations: String = r.<<
+      // val symbolSynonyms: String = r.<<
+      // val synonyms: String = r.<<
+      // val targetClass: String = r.<<
+      // val tep: String = r.<<?
+      // val tractability: String = r.<<
+      // val transcriptIds: String = r.<<
+      Target(
+        id = r.<<[String],
+        alternativeGenes = StrSeqRep(r.<<[String]).rep,
+        approvedName = r.<<[String],
+        approvedSymbol = r.<<[String],
+        biotype = r.<<[String],
+        chemicalProbes = TupleSeqRep[ChemicalProbe](r.<<[String], chemicalProbeParser).rep,
+        constraint = TupleSeqRep[Constraint](r.<<[String], constraintParser).rep,
+        dbXrefs = r.nextObject().asInstanceOf[Seq[IdAndSource]],
+        functionDescriptions = 
+      )
+    }
 
-  implicit val chemicalProbeUrlImp: OFormat[ChemicalProbeUrl] = Json.format[ChemicalProbeUrl]
-  implicit val chemicalProbeImp: OFormat[ChemicalProbe] = Json.format[ChemicalProbe]
+  class ChemicalProbeParser(str: String) extends StringParser[ChemicalProbe](str) {
+    override def parse: ChemicalProbe =
+      ChemicalProbe(
+        id = tokens(0),
+        control = optionalValue(tokens(1))(identity),
+        drugId = optionalValue(tokens(2))(identity),
+        mechanismOfAction = optionalValue(tokens(3))(s => StrSeqRep(s).rep),
+        isHighQuality = tokens(4).toBoolean,
+        origin = optionalValue(tokens(5))(s => StrSeqRep(s).rep),
+        probeMinerScore = optionalValue(tokens(6))(_.toDouble),
+        probesDrugsScore = optionalValue(tokens(7))(_.toDouble),
+        scoreInCells = optionalValue(tokens(8))(_.toDouble),
+        scoreInOrganisms = optionalValue(tokens(9))(_.toDouble),
+        targetFromSourceId = tokens(10),
+        urls = TupleSeqRep(tokens(11), chemicalProbeUrlParser).rep
+      )
+  }
 
-  implicit val hallmarkAttributeImpW: OWrites[HallmarkAttribute] = Json.writes[HallmarkAttribute]
-  implicit val hallmarkAttributeImpR: Reads[HallmarkAttribute] =
-    ((__ \ "attribute_name").read[String] and
-      (__ \ "description").read[String] and
-      (__ \ "pmid").readNullable[Long])(HallmarkAttribute.apply)
+  class ChemicalProbeUrlParser(str: String) extends StringParser[ChemicalProbeUrl](str) {
+    override def parse: ChemicalProbeUrl =
+      ChemicalProbeUrl(
+        niceName = tokens(0),
+        url = optionalValue(tokens(1))(identity)
+      )
+  }
 
-  implicit val hallmarksImpW: OWrites[Hallmarks] = Json.writes[Hallmarks]
-  implicit val hallmarksImpR: Reads[Hallmarks] =
-    ((__ \ "cancerHallmarks").readWithDefault[Seq[CancerHallmark]](Seq.empty) and
-      (__ \ "attributes").readWithDefault[Seq[HallmarkAttribute]](Seq.empty))(Hallmarks.apply)
+  class ConstraintParser(str: String) extends StringParser[Constraint](str) {
+    override def parse: Constraint =
+      Constraint(
+        constraintType = tokens(0),
+        exp = optionalValue(tokens(1))(_.toDouble),
+        obs = optionalValue(tokens(2))(_.toLong),
+        oe = optionalValue(tokens(3))(_.toDouble),
+        oeLower = optionalValue(tokens(4))(_.toDouble),
+        oeUpper = optionalValue(tokens(5))(_.toDouble),
+        score = optionalValue(tokens(6))(_.toDouble),
+        upperBin = optionalValue(tokens(7))(_.toLong),
+        upperBin6 = optionalValue(tokens(8))(_.toLong),
+        upperRank = optionalValue(tokens(9))(_.toLong)
+      )
+  }
+  // Parser functions
+  val chemicalProbeParser: String => ChemicalProbe = str => new ChemicalProbeParser(str).parse
+  val chemicalProbeUrlParser: String => ChemicalProbeUrl = str =>
+    new ChemicalProbeUrlParser(str).parse
+  val constraintParser: String => Constraint = str => new ConstraintParser(str).parse
 
-  implicit val geneOntologyImpW: OWrites[GeneOntology] = Json.writes[models.entities.GeneOntology]
-  implicit val geneOntologyImpR: Reads[models.entities.GeneOntology] =
-    ((__ \ "id").read[String] and
-      (__ \ "aspect").read[String] and
-      (__ \ "evidence").read[String] and
-      (__ \ "geneProduct").read[String] and
-      (__ \ "source").read[String])(GeneOntology.apply)
+  // val chemicalProbeParser: String => ChemicalProbe = str => {
+  //   val tokens = str.split(",")
+  //   ChemicalProbe(
+  //     id = tokens(0),
+  //     control = if (tokens(1).isEmpty) None else Some(tokens(1)),
+  //     drugId = if (tokens(2).isEmpty) None else Some(tokens(2)),
+  //     mechanismOfAction = if (tokens(3).isEmpty) None else Some(StrSeqRep(tokens(3)).rep),
+  //     isHighQuality = tokens(4).toBoolean,
+  //     origin = if (tokens(5).isEmpty) None else Some(StrSeqRep(tokens(5)).rep),
+  //     probeMinerScore = if (tokens(6).isEmpty) None else Some(tokens(6).toDouble),
+  //     probesDrugsScore = if (tokens(7).isEmpty) None else Some(tokens(7).toDouble),
+  //     scoreInCells = if (tokens(8).isEmpty) None else Some(tokens(8).toDouble),
+  //     scoreInOrganisms = if (tokens(9).isEmpty) None else Some(tokens(9).toDouble),
+  //     targetFromSourceId = tokens(10),
+  //     urls = TupleSeqRep(tokens(11), chemicalProbeUrlParser).rep
+  //   )
+  // }
+  // val chemicalProbeUrlParser: String => ChemicalProbeUrl = str => {
+  //   val tokens = str.split(",")
+  //   ChemicalProbeUrl(
+  //     niceName = tokens(0),
+  //     url = if (tokens(1).isEmpty) None else Some(tokens(1))
+  //   )
+  // }
+
+  // implicit val cancerHallmarkImpW: OWrites[CancerHallmark] = Json.writes[CancerHallmark]
+  // implicit val cancerHallmarkImpR: Reads[CancerHallmark] =
+  //   ((__ \ "description").read[String] and
+  //     (__ \ "impact").readNullable[String] and
+  //     (__ \ "label").read[String] and
+  //     (__ \ "pmid").read[Long])(CancerHallmark.apply)
+
+  // implicit val chemicalProbeUrlImp: OFormat[ChemicalProbeUrl] = Json.format[ChemicalProbeUrl]
+  // implicit val chemicalProbeImp: OFormat[ChemicalProbe] = Json.format[ChemicalProbe]
+
+  // implicit val hallmarkAttributeImpW: OWrites[HallmarkAttribute] = Json.writes[HallmarkAttribute]
+  // implicit val hallmarkAttributeImpR: Reads[HallmarkAttribute] =
+  //   ((__ \ "attribute_name").read[String] and
+  //     (__ \ "description").read[String] and
+  //     (__ \ "pmid").readNullable[Long])(HallmarkAttribute.apply)
+
+  // implicit val hallmarksImpW: OWrites[Hallmarks] = Json.writes[Hallmarks]
+  // implicit val hallmarksImpR: Reads[Hallmarks] =
+  //   ((__ \ "cancerHallmarks").readWithDefault[Seq[CancerHallmark]](Seq.empty) and
+  //     (__ \ "attributes").readWithDefault[Seq[HallmarkAttribute]](Seq.empty))(Hallmarks.apply)
+
+  // implicit val geneOntologyImpW: OWrites[GeneOntology] = Json.writes[models.entities.GeneOntology]
+  // implicit val geneOntologyImpR: Reads[models.entities.GeneOntology] =
+  //   ((__ \ "id").read[String] and
+  //     (__ \ "aspect").read[String] and
+  //     (__ \ "evidence").read[String] and
+  //     (__ \ "geneProduct").read[String] and
+  //     (__ \ "source").read[String])(GeneOntology.apply)
 
   implicit val tepImpF: OFormat[Tep] = Json.format[Tep]
   implicit val idAndSourceImpF: OFormat[IdAndSource] = Json.format[IdAndSource]
@@ -191,5 +311,5 @@ object Target extends Logging {
   implicit val reactomePathwayImpF: OFormat[ReactomePathway] =
     Json.format[models.entities.ReactomePathway]
   implicit val targetImpF: OFormat[Target] =
-    Json.format[models.entities.Target]
+    Json.format[Target]
 }

--- a/app/models/entities/Target.scala
+++ b/app/models/entities/Target.scala
@@ -152,93 +152,93 @@ case class Target(
 object Target extends Logging {
 
   implicit val getTargetFromDB: GetResult[Target] =
-    GetResult { r =>
-      // val id: String = r.<<
-      // val alternativeGenes: String = r.<<
-      // val approvedName: String = r.<<
-      // val approvedSymbol: String = r.<<
-      // val biotype: String = r.<<
-      // val chemicalProbes: String = r.<<
-      // val constraint: String = r.<<
-      // val dbXrefs: String = r.<<
-      // val functionDescriptions: String = r.<<
-      // val genomicLocation: String = r.<<
-      // val go: String = r.<<
-      // val hallmarks: String = r.<<?
-      // val homologues: String = r.<<
-      // val nameSynonyms: String = r.<<
-      // val obsoleteNames: String = r.<<
-      // val obsoleteSymbols: String = r.<<
-      // val pathways: String = r.<<
-      // val proteinIds: String = r.<<
-      // val safetyLiabilities: String = r.<<
-      // val studyIds: String = r.<<
-      // val subcellularLocations: String = r.<<
-      // val symbolSynonyms: String = r.<<
-      // val synonyms: String = r.<<
-      // val targetClass: String = r.<<
-      // val tep: String = r.<<?
-      // val tractability: String = r.<<
-      // val transcriptIds: String = r.<<
-      Target(
-        id = r.<<[String],
-        alternativeGenes = StrSeqRep(r.<<[String]).rep,
-        approvedName = r.<<[String],
-        approvedSymbol = r.<<[String],
-        biotype = r.<<[String],
-        chemicalProbes = TupleSeqRep[ChemicalProbe](r.<<[String], chemicalProbeParser).rep,
-        constraint = TupleSeqRep[Constraint](r.<<[String], constraintParser).rep,
-        dbXrefs = r.nextObject().asInstanceOf[Seq[IdAndSource]],
-        functionDescriptions = 
-      )
-    }
+    GetResult(r => Json.parse(r.<<[String]).as[Target])
+  // val id: String = r.<<
+  // val alternativeGenes: String = r.<<
+  // val approvedName: String = r.<<
+  // val approvedSymbol: String = r.<<
+  // val biotype: String = r.<<
+  // val chemicalProbes: String = r.<<
+  // val constraint: String = r.<<
+  // val dbXrefs: String = r.<<
+  // val functionDescriptions: String = r.<<
+  // val genomicLocation: String = r.<<
+  // val go: String = r.<<
+  // val hallmarks: String = r.<<?
+  // val homologues: String = r.<<
+  // val nameSynonyms: String = r.<<
+  // val obsoleteNames: String = r.<<
+  // val obsoleteSymbols: String = r.<<
+  // val pathways: String = r.<<
+  // val proteinIds: String = r.<<
+  // val safetyLiabilities: String = r.<<
+  // val studyIds: String = r.<<
+  // val subcellularLocations: String = r.<<
+  // val symbolSynonyms: String = r.<<
+  // val synonyms: String = r.<<
+  // val targetClass: String = r.<<
+  // val tep: String = r.<<?
+  // val tractability: String = r.<<
+  // val transcriptIds: String = r.<<
+  //     Target(
+  //       id = r.<<[String],
+  //       alternativeGenes = StrSeqRep(r.<<[String]).rep,
+  //       approvedName = r.<<[String],
+  //       approvedSymbol = r.<<[String],
+  //       biotype = r.<<[String],
+  //       chemicalProbes = TupleSeqRep[ChemicalProbe](r.<<[String], chemicalProbeParser).rep,
+  //       constraint = TupleSeqRep[Constraint](r.<<[String], constraintParser).rep,
+  //       dbXrefs = r.nextObject().asInstanceOf[Seq[IdAndSource]],
+  //       functionDescriptions =
+  //     )
+  //   }
 
-  class ChemicalProbeParser(str: String) extends StringParser[ChemicalProbe](str) {
-    override def parse: ChemicalProbe =
-      ChemicalProbe(
-        id = tokens(0),
-        control = optionalValue(tokens(1))(identity),
-        drugId = optionalValue(tokens(2))(identity),
-        mechanismOfAction = optionalValue(tokens(3))(s => StrSeqRep(s).rep),
-        isHighQuality = tokens(4).toBoolean,
-        origin = optionalValue(tokens(5))(s => StrSeqRep(s).rep),
-        probeMinerScore = optionalValue(tokens(6))(_.toDouble),
-        probesDrugsScore = optionalValue(tokens(7))(_.toDouble),
-        scoreInCells = optionalValue(tokens(8))(_.toDouble),
-        scoreInOrganisms = optionalValue(tokens(9))(_.toDouble),
-        targetFromSourceId = tokens(10),
-        urls = TupleSeqRep(tokens(11), chemicalProbeUrlParser).rep
-      )
-  }
+  // class ChemicalProbeParser(str: String) extends StringParser[ChemicalProbe](str) {
+  //   override def parse: ChemicalProbe =
+  //     ChemicalProbe(
+  //       id = tokens(0),
+  //       control = optionalValue(tokens(1))(identity),
+  //       drugId = optionalValue(tokens(2))(identity),
+  //       mechanismOfAction = optionalValue(tokens(3))(s => StrSeqRep(s).rep),
+  //       isHighQuality = tokens(4).toBoolean,
+  //       origin = optionalValue(tokens(5))(s => StrSeqRep(s).rep),
+  //       probeMinerScore = optionalValue(tokens(6))(_.toDouble),
+  //       probesDrugsScore = optionalValue(tokens(7))(_.toDouble),
+  //       scoreInCells = optionalValue(tokens(8))(_.toDouble),
+  //       scoreInOrganisms = optionalValue(tokens(9))(_.toDouble),
+  //       targetFromSourceId = tokens(10),
+  //       urls = TupleSeqRep(tokens(11), chemicalProbeUrlParser).rep
+  //     )
+  // }
 
-  class ChemicalProbeUrlParser(str: String) extends StringParser[ChemicalProbeUrl](str) {
-    override def parse: ChemicalProbeUrl =
-      ChemicalProbeUrl(
-        niceName = tokens(0),
-        url = optionalValue(tokens(1))(identity)
-      )
-  }
+  // class ChemicalProbeUrlParser(str: String) extends StringParser[ChemicalProbeUrl](str) {
+  //   override def parse: ChemicalProbeUrl =
+  //     ChemicalProbeUrl(
+  //       niceName = tokens(0),
+  //       url = optionalValue(tokens(1))(identity)
+  //     )
+  // }
 
-  class ConstraintParser(str: String) extends StringParser[Constraint](str) {
-    override def parse: Constraint =
-      Constraint(
-        constraintType = tokens(0),
-        exp = optionalValue(tokens(1))(_.toDouble),
-        obs = optionalValue(tokens(2))(_.toLong),
-        oe = optionalValue(tokens(3))(_.toDouble),
-        oeLower = optionalValue(tokens(4))(_.toDouble),
-        oeUpper = optionalValue(tokens(5))(_.toDouble),
-        score = optionalValue(tokens(6))(_.toDouble),
-        upperBin = optionalValue(tokens(7))(_.toLong),
-        upperBin6 = optionalValue(tokens(8))(_.toLong),
-        upperRank = optionalValue(tokens(9))(_.toLong)
-      )
-  }
-  // Parser functions
-  val chemicalProbeParser: String => ChemicalProbe = str => new ChemicalProbeParser(str).parse
-  val chemicalProbeUrlParser: String => ChemicalProbeUrl = str =>
-    new ChemicalProbeUrlParser(str).parse
-  val constraintParser: String => Constraint = str => new ConstraintParser(str).parse
+  // class ConstraintParser(str: String) extends StringParser[Constraint](str) {
+  //   override def parse: Constraint =
+  //     Constraint(
+  //       constraintType = tokens(0),
+  //       exp = optionalValue(tokens(1))(_.toDouble),
+  //       obs = optionalValue(tokens(2))(_.toLong),
+  //       oe = optionalValue(tokens(3))(_.toDouble),
+  //       oeLower = optionalValue(tokens(4))(_.toDouble),
+  //       oeUpper = optionalValue(tokens(5))(_.toDouble),
+  //       score = optionalValue(tokens(6))(_.toDouble),
+  //       upperBin = optionalValue(tokens(7))(_.toLong),
+  //       upperBin6 = optionalValue(tokens(8))(_.toLong),
+  //       upperRank = optionalValue(tokens(9))(_.toLong)
+  //     )
+  // }
+  // // Parser functions
+  // val chemicalProbeParser: String => ChemicalProbe = str => new ChemicalProbeParser(str).parse
+  // val chemicalProbeUrlParser: String => ChemicalProbeUrl = str =>
+  //   new ChemicalProbeUrlParser(str).parse
+  // val constraintParser: String => Constraint = str => new ConstraintParser(str).parse
 
   // val chemicalProbeParser: String => ChemicalProbe = str => {
   //   val tokens = str.split(",")
@@ -310,6 +310,18 @@ object Target extends Logging {
     Json.format[models.entities.GenomicLocation]
   implicit val reactomePathwayImpF: OFormat[ReactomePathway] =
     Json.format[models.entities.ReactomePathway]
+  implicit val chemicalProbeF: OFormat[ChemicalProbe] =
+    Json.format[models.entities.ChemicalProbe]
+  implicit val chemicalProbeUrlF: OFormat[ChemicalProbeUrl] =
+    Json.format[models.entities.ChemicalProbeUrl]
+  implicit val geneOntologyImpF: OFormat[GeneOntology] = Json.format[models.entities.GeneOntology]
+  implicit val geneOntologyLookupImpF: OFormat[GeneOntologyLookup] =
+    Json.format[models.entities.GeneOntologyLookup]
+  implicit val cancerHallmarkImpF: OFormat[CancerHallmark] =
+    Json.format[models.entities.CancerHallmark]
+  implicit val hallmarkAttributeImpF: OFormat[HallmarkAttribute] =
+    Json.format[models.entities.HallmarkAttribute]
+  implicit val hallmarksImpF: OFormat[Hallmarks] = Json.format[models.entities.Hallmarks]
   implicit val targetImpF: OFormat[Target] =
     Json.format[Target]
 }

--- a/app/models/entities/Target.scala
+++ b/app/models/entities/Target.scala
@@ -7,8 +7,14 @@ import play.api.libs.json.Reads._
 import play.api.libs.json._
 import slick.jdbc.GetResult
 import models.gql.Arguments.studyIds
-import org.checkerframework.checker.units.qual.g
-import org.checkerframework.checker.units.qual.t
+
+case class CanonicalTranscript(
+    id: String,
+    chromosome: String,
+    start: Long,
+    end: Long,
+    strand: String
+)
 
 case class ChemicalProbeUrl(niceName: String, url: Option[String])
 
@@ -125,8 +131,9 @@ case class Target(
     approvedName: String,
     approvedSymbol: String,
     biotype: String,
+    canonicalTranscript: Option[CanonicalTranscript] = None,
     chemicalProbes: Seq[ChemicalProbe] = Seq.empty,
-    constraint: Seq[Constraint] = Seq.empty,
+    constraint: Seq[Constraint], // = Seq.empty,
     dbXrefs: Seq[IdAndSource] = Seq.empty,
     functionDescriptions: Seq[String] = Seq.empty,
     genomicLocation: GenomicLocation,
@@ -139,7 +146,7 @@ case class Target(
     pathways: Seq[ReactomePathway] = Seq.empty,
     proteinIds: Seq[IdAndSource] = Seq.empty,
     safetyLiabilities: Seq[SafetyLiability] = Seq.empty,
-    studyIds: Seq[String] = Seq.empty,
+    studyLocusIds: Seq[String] = Seq.empty,
     subcellularLocations: Seq[LocationAndSource] = Seq.empty,
     symbolSynonyms: Seq[LabelAndSource] = Seq.empty,
     synonyms: Seq[LabelAndSource] = Seq.empty, // double check, this is name and symbol
@@ -153,146 +160,6 @@ object Target extends Logging {
 
   implicit val getTargetFromDB: GetResult[Target] =
     GetResult(r => Json.parse(r.<<[String]).as[Target])
-  // val id: String = r.<<
-  // val alternativeGenes: String = r.<<
-  // val approvedName: String = r.<<
-  // val approvedSymbol: String = r.<<
-  // val biotype: String = r.<<
-  // val chemicalProbes: String = r.<<
-  // val constraint: String = r.<<
-  // val dbXrefs: String = r.<<
-  // val functionDescriptions: String = r.<<
-  // val genomicLocation: String = r.<<
-  // val go: String = r.<<
-  // val hallmarks: String = r.<<?
-  // val homologues: String = r.<<
-  // val nameSynonyms: String = r.<<
-  // val obsoleteNames: String = r.<<
-  // val obsoleteSymbols: String = r.<<
-  // val pathways: String = r.<<
-  // val proteinIds: String = r.<<
-  // val safetyLiabilities: String = r.<<
-  // val studyIds: String = r.<<
-  // val subcellularLocations: String = r.<<
-  // val symbolSynonyms: String = r.<<
-  // val synonyms: String = r.<<
-  // val targetClass: String = r.<<
-  // val tep: String = r.<<?
-  // val tractability: String = r.<<
-  // val transcriptIds: String = r.<<
-  //     Target(
-  //       id = r.<<[String],
-  //       alternativeGenes = StrSeqRep(r.<<[String]).rep,
-  //       approvedName = r.<<[String],
-  //       approvedSymbol = r.<<[String],
-  //       biotype = r.<<[String],
-  //       chemicalProbes = TupleSeqRep[ChemicalProbe](r.<<[String], chemicalProbeParser).rep,
-  //       constraint = TupleSeqRep[Constraint](r.<<[String], constraintParser).rep,
-  //       dbXrefs = r.nextObject().asInstanceOf[Seq[IdAndSource]],
-  //       functionDescriptions =
-  //     )
-  //   }
-
-  // class ChemicalProbeParser(str: String) extends StringParser[ChemicalProbe](str) {
-  //   override def parse: ChemicalProbe =
-  //     ChemicalProbe(
-  //       id = tokens(0),
-  //       control = optionalValue(tokens(1))(identity),
-  //       drugId = optionalValue(tokens(2))(identity),
-  //       mechanismOfAction = optionalValue(tokens(3))(s => StrSeqRep(s).rep),
-  //       isHighQuality = tokens(4).toBoolean,
-  //       origin = optionalValue(tokens(5))(s => StrSeqRep(s).rep),
-  //       probeMinerScore = optionalValue(tokens(6))(_.toDouble),
-  //       probesDrugsScore = optionalValue(tokens(7))(_.toDouble),
-  //       scoreInCells = optionalValue(tokens(8))(_.toDouble),
-  //       scoreInOrganisms = optionalValue(tokens(9))(_.toDouble),
-  //       targetFromSourceId = tokens(10),
-  //       urls = TupleSeqRep(tokens(11), chemicalProbeUrlParser).rep
-  //     )
-  // }
-
-  // class ChemicalProbeUrlParser(str: String) extends StringParser[ChemicalProbeUrl](str) {
-  //   override def parse: ChemicalProbeUrl =
-  //     ChemicalProbeUrl(
-  //       niceName = tokens(0),
-  //       url = optionalValue(tokens(1))(identity)
-  //     )
-  // }
-
-  // class ConstraintParser(str: String) extends StringParser[Constraint](str) {
-  //   override def parse: Constraint =
-  //     Constraint(
-  //       constraintType = tokens(0),
-  //       exp = optionalValue(tokens(1))(_.toDouble),
-  //       obs = optionalValue(tokens(2))(_.toLong),
-  //       oe = optionalValue(tokens(3))(_.toDouble),
-  //       oeLower = optionalValue(tokens(4))(_.toDouble),
-  //       oeUpper = optionalValue(tokens(5))(_.toDouble),
-  //       score = optionalValue(tokens(6))(_.toDouble),
-  //       upperBin = optionalValue(tokens(7))(_.toLong),
-  //       upperBin6 = optionalValue(tokens(8))(_.toLong),
-  //       upperRank = optionalValue(tokens(9))(_.toLong)
-  //     )
-  // }
-  // // Parser functions
-  // val chemicalProbeParser: String => ChemicalProbe = str => new ChemicalProbeParser(str).parse
-  // val chemicalProbeUrlParser: String => ChemicalProbeUrl = str =>
-  //   new ChemicalProbeUrlParser(str).parse
-  // val constraintParser: String => Constraint = str => new ConstraintParser(str).parse
-
-  // val chemicalProbeParser: String => ChemicalProbe = str => {
-  //   val tokens = str.split(",")
-  //   ChemicalProbe(
-  //     id = tokens(0),
-  //     control = if (tokens(1).isEmpty) None else Some(tokens(1)),
-  //     drugId = if (tokens(2).isEmpty) None else Some(tokens(2)),
-  //     mechanismOfAction = if (tokens(3).isEmpty) None else Some(StrSeqRep(tokens(3)).rep),
-  //     isHighQuality = tokens(4).toBoolean,
-  //     origin = if (tokens(5).isEmpty) None else Some(StrSeqRep(tokens(5)).rep),
-  //     probeMinerScore = if (tokens(6).isEmpty) None else Some(tokens(6).toDouble),
-  //     probesDrugsScore = if (tokens(7).isEmpty) None else Some(tokens(7).toDouble),
-  //     scoreInCells = if (tokens(8).isEmpty) None else Some(tokens(8).toDouble),
-  //     scoreInOrganisms = if (tokens(9).isEmpty) None else Some(tokens(9).toDouble),
-  //     targetFromSourceId = tokens(10),
-  //     urls = TupleSeqRep(tokens(11), chemicalProbeUrlParser).rep
-  //   )
-  // }
-  // val chemicalProbeUrlParser: String => ChemicalProbeUrl = str => {
-  //   val tokens = str.split(",")
-  //   ChemicalProbeUrl(
-  //     niceName = tokens(0),
-  //     url = if (tokens(1).isEmpty) None else Some(tokens(1))
-  //   )
-  // }
-
-  // implicit val cancerHallmarkImpW: OWrites[CancerHallmark] = Json.writes[CancerHallmark]
-  // implicit val cancerHallmarkImpR: Reads[CancerHallmark] =
-  //   ((__ \ "description").read[String] and
-  //     (__ \ "impact").readNullable[String] and
-  //     (__ \ "label").read[String] and
-  //     (__ \ "pmid").read[Long])(CancerHallmark.apply)
-
-  // implicit val chemicalProbeUrlImp: OFormat[ChemicalProbeUrl] = Json.format[ChemicalProbeUrl]
-  // implicit val chemicalProbeImp: OFormat[ChemicalProbe] = Json.format[ChemicalProbe]
-
-  // implicit val hallmarkAttributeImpW: OWrites[HallmarkAttribute] = Json.writes[HallmarkAttribute]
-  // implicit val hallmarkAttributeImpR: Reads[HallmarkAttribute] =
-  //   ((__ \ "attribute_name").read[String] and
-  //     (__ \ "description").read[String] and
-  //     (__ \ "pmid").readNullable[Long])(HallmarkAttribute.apply)
-
-  // implicit val hallmarksImpW: OWrites[Hallmarks] = Json.writes[Hallmarks]
-  // implicit val hallmarksImpR: Reads[Hallmarks] =
-  //   ((__ \ "cancerHallmarks").readWithDefault[Seq[CancerHallmark]](Seq.empty) and
-  //     (__ \ "attributes").readWithDefault[Seq[HallmarkAttribute]](Seq.empty))(Hallmarks.apply)
-
-  // implicit val geneOntologyImpW: OWrites[GeneOntology] = Json.writes[models.entities.GeneOntology]
-  // implicit val geneOntologyImpR: Reads[models.entities.GeneOntology] =
-  //   ((__ \ "id").read[String] and
-  //     (__ \ "aspect").read[String] and
-  //     (__ \ "evidence").read[String] and
-  //     (__ \ "geneProduct").read[String] and
-  //     (__ \ "source").read[String])(GeneOntology.apply)
 
   implicit val tepImpF: OFormat[Tep] = Json.format[Tep]
   implicit val idAndSourceImpF: OFormat[IdAndSource] = Json.format[IdAndSource]
@@ -300,6 +167,8 @@ object Target extends Logging {
   implicit val locationAndSourceImpF: OFormat[LocationAndSource] = Json.format[LocationAndSource]
   implicit val targetClassImpF: OFormat[TargetClass] = Json.format[TargetClass]
   implicit val tractabilityImpF: OFormat[Tractability] = Json.format[Tractability]
+  implicit val canonicalTranscriptImpF: OFormat[CanonicalTranscript] =
+    Json.format[CanonicalTranscript]
   implicit val constraintImpF: OFormat[Constraint] = Json.format[Constraint]
   implicit val homologueImpF: OFormat[Homologue] = Json.format[Homologue]
   implicit val doseAndTypeImpF: OFormat[SafetyEffects] = Json.format[SafetyEffects]

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -106,6 +106,25 @@ object Objects extends Logging {
     DocumentField("pathways", "Reactome pathways"),
     RenameField("go", "geneOntology"),
     RenameField("constraint", "geneticConstraint"),
+    ReplaceField(
+      "studyLocusIds",
+      Field(
+        "credibleSets",
+        credibleSetsImp,
+        description = None,
+        arguments = pageArg :: Nil,
+        complexity = Some(complexityCalculator(pageArg)),
+        resolve = ctx =>
+          if (ctx.value.studyLocusIds.isEmpty) {
+            Future.successful(CredibleSets.empty)
+          } else {
+            val credSetQueryArgs = CredibleSetQueryArgs(
+              ctx.value.studyLocusIds
+            )
+            ctx.ctx.getCredibleSets(credSetQueryArgs, ctx.arg(pageArg))
+          }
+      )
+    ),
     AddFields(
       Field(
         "similarEntities",
@@ -681,6 +700,8 @@ object Objects extends Logging {
     deriveObjectType[Backend, TargetClass]()
   implicit val doseTypeImp: ObjectType[Backend, SafetyEffects] =
     deriveObjectType[Backend, SafetyEffects]()
+  implicit val canonicalTranscriptImp: ObjectType[Backend, CanonicalTranscript] =
+    deriveObjectType[Backend, CanonicalTranscript]()
   implicit val constraintImp: ObjectType[Backend, Constraint] =
     deriveObjectType[Backend, Constraint]()
   implicit val homologueImp: ObjectType[Backend, Homologue] = deriveObjectType[Backend, Homologue]()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -36,6 +36,8 @@ ot {
       name = "ot.ml_w2v"
     }
     target {
+      label = "Target table"
+      name = "ot.targets"
       associations {
         label = "Association table for targets"
         name = "ot.associations_otf_target"


### PR DESCRIPTION
- as part of opentargets/issues#3892
- added target to clickhouse instead of opensearch
- credible set resolved using a pre-merged set of studyLocusIds in the target data
- added CanonicalTranscript to Target