### PR TITLE
fix pagination on intervals, change default sort on intervals

### DIFF
--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -864,14 +864,14 @@ class Backend @Inject() (implicit
                    pagination: Option[Pagination]
   ): Future[Intervals] = {
     val tableName = defaultOTSettings.clickhouse.intervals.name
-    val page = pagination.getOrElse(Pagination.mkDefault)
+    val page = pagination.getOrElse(Pagination.mkDefault).offsetLimit
     val intervalsQuery = IntervalsQuery(
       chromosome,
       start,
       end,
       tableName,
-      page.index,
-      page.size
+      page._1,
+      page._2
     )
     val total: Int = dbRetriever
       .executeQuery[Int, Query](intervalsQuery.totals)

--- a/app/models/db/IntervalsQuery.scala
+++ b/app/models/db/IntervalsQuery.scala
@@ -36,7 +36,7 @@ case class IntervalsQuery(chromosome: String,
       ),
       From(column(tableName)),
       positionalQuery,
-      OrderBy(column("chromosome") :: column("start") :: column("end") :: Nil),
+      OrderBy(column("score").desc :: Nil),
       Limit(offset, size),
       Format("JSONEachRow")
     )

--- a/app/models/entities/Pagination.scala
+++ b/app/models/entities/Pagination.scala
@@ -21,12 +21,12 @@ case class Pagination(index: Int, size: Int) {
 
   def hasValidRange(maxSize: Int = Pagination.sizeMax): Boolean = size <= maxSize
 
-  val toSQL: String = (index, size) match {
-    case (0, 0) => s"LIMIT ${Pagination.sizeDefault}"
-    case (0, s) => s"LIMIT $s"
-    case (i, 0) => s"LIMIT ${i * Pagination.sizeDefault}, ${Pagination.sizeDefault}"
-    case (i, s) => s"LIMIT ${i * s} , $s"
-    case null   => s"LIMIT ${Pagination.indexDefault}, ${Pagination.sizeDefault}"
+  val offsetLimit: (Int, Int) = (index, size) match {
+    case (0, 0) => (0, Pagination.sizeDefault)
+    case (0, s) => (0, s)
+    case (i, 0) => (i * Pagination.sizeDefault, Pagination.sizeDefault)
+    case (i, s) => (i * s, s)
+    case null   => (0, Pagination.sizeDefault)
   }
 
   val toES: (Int, Int) = (index, size) match {


### PR DESCRIPTION
as part of opentargets/issues#4055
- fix pagination on intervals
- set default interval sort order to desc by score