### PR TITLE
enable gzip filter

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -271,7 +271,7 @@ play {
       play.filters.csp.CSPFilter,
       play.filters.csrf.CSRFFilter,
       play.filters.headers.SecurityHeadersFilter]
-    enabled = [play.filters.cors.CORSFilter]
+    enabled = [play.filters.cors.CORSFilter, play.filters.gzip.GzipFilter]
   }
 
 


### PR DESCRIPTION
This item solves the issue [4086](https://github.com/opentargets/issues/issues/4086). By enabling the gzip filter. With the current configuration the compression level will be set to the default value which is -1 (equivalent to 6) or balanced.