### PR TITLE
Fix search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ debug_log_standalone: ## Debugs API using the logback file specified in logfile 
 
 es_tunnel: ## Create tunnel connection to OpenSearch. E.g.: make es_tunnel zone=europe-west1-d instance=trnplt-es-0-esearch-fl6c
 	@echo "Connecting to OpenSearch"
-	@gcloud compute ssh --zone "${zone}" --tunnel-through-iap ${instance} -- -L 9200:localhost:9200 -N
+	@gcloud compute ssh --zone "${zone}" --project "${project}" --tunnel-through-iap ${instance} -- -L 9200:localhost:9200 -N
 
 ch_tunnel: ## Create tunnel connection to ClickHouse. E.g.: make ch_tunnel zone=europe-west1-d instance=trnplt-es-0-esearch-fl6c
 	@echo "Connecting to ClickHouse"
-	@gcloud compute ssh --zone "${zone}" --tunnel-through-iap ${instance} -- -L 8123:localhost:8123 -N
+	@gcloud compute ssh --zone "${zone}" --project "${project}" --tunnel-through-iap ${instance} -- -L 8123:localhost:8123 -N
 
 run_with_standalone: ## Runs API with standalone platform
 	@sbt "run 8090" -J-Xms2g -J-Xmx7g -J-XX:+UseG1GC -DPLATFORM_API_IGNORE_CACHE=true -DELASTICSEARCH_HOST=elasticsearch -DSLICK_CLICKHOUSE_URL=jdbc:clickhouse://clickhouse:8123

--- a/app/models/Backend.scala
+++ b/app/models/Backend.scala
@@ -910,9 +910,14 @@ class Backend @Inject() (implicit
       pagination: Option[Pagination],
       entityNames: Seq[String]
   ): Future[SearchResults] = {
-    val entities = for {
-      e <- defaultESSettings.entities if (entityNames.contains(e.name) && e.searchIndex.isDefined)
-    } yield e.copy(searchIndex = Some(getIndexWithPrefixOrDefault(e.searchIndex.getOrElse(""))))
+    val entities = entityNames match {
+      case Nil => defaultESSettings.entities.filter(_.searchIndex.isDefined)
+      case _ =>
+        defaultESSettings.entities
+          .filter(e => entityNames.contains(e.name) && e.searchIndex.isDefined)
+    } map (e =>
+      e.copy(searchIndex = Some(getIndexWithPrefixOrDefault(e.searchIndex.getOrElse(""))))
+    )
     esRetriever.getSearchResultSet(entities, qString, pagination.getOrElse(Pagination.mkDefault))
   }
 
@@ -922,10 +927,14 @@ class Backend @Inject() (implicit
       entityNames: Seq[String],
       category: Option[String]
   ): Future[SearchFacetsResults] = {
-    val entities = for {
-      e <- defaultESSettings.entities
-      if (entityNames.contains(e.name) && e.facetSearchIndex.isDefined)
-    } yield e.copy(searchIndex = Some(getIndexWithPrefixOrDefault(e.searchIndex.getOrElse(""))))
+    val entities = entityNames match {
+      case Nil => defaultESSettings.entities.filter(_.facetSearchIndex.isDefined)
+      case _ =>
+        defaultESSettings.entities
+          .filter(e => entityNames.contains(e.name) && e.facetSearchIndex.isDefined)
+    } map (e =>
+      e.copy(searchIndex = Some(getIndexWithPrefixOrDefault(e.searchIndex.getOrElse(""))))
+    )
     esRetriever.getSearchFacetsResultSet(entities,
                                          qString,
                                          pagination.getOrElse(Pagination.mkDefault),


### PR DESCRIPTION
This PR ensures we don't query all indices in the OpenSearch instance when searching, but only those in the correct namespace.