### PR TITLE
Revert "added interval for lead variant of credible set"

### DIFF
--- a/app/models/entities/CredibleSet.scala
+++ b/app/models/entities/CredibleSet.scala
@@ -10,9 +10,9 @@ case class LdSet(
 )
 
 case class CredibleSet(studyLocusId: String,
-                       variantId: String,
-                       chromosome: String,
-                       position: Int,
+                       variantId: Option[String],
+                       chromosome: Option[String],
+                       position: Option[Int],
                        region: Option[String],
                        studyId: Option[String],
                        beta: Option[Double],

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1942,19 +1942,6 @@ object Objects extends Logging {
             logger.debug(s"Finding gwas study: $studyId")
             studyFetcher.deferOpt(studyId)
           }
-        ),
-        Field(
-          "intervals",
-          intervalsImp,
-          description = Some("Intervals for the lead variant of the credible set"),
-          arguments = pageArg :: Nil,
-          complexity = Some(complexityCalculator(pageArg)),
-          resolve = ctx =>
-            ctx.ctx.getIntervals(ctx.value.chromosome,
-                                 ctx.value.position,
-                                 ctx.value.position,
-                                 ctx.arg(pageArg)
-            )
         )
       )
     )


### PR DESCRIPTION
Reverts opentargets/platform-api#294
- same can be achieved by accessing `CredibleSet.Variant.Intervals` as Variant is already resolved on the lead variant
