### PR TITLE
3947 filter aotf for non measurement terms

### DIFF
--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -244,4 +244,10 @@ object Arguments {
     OptionInputType(ListInputType(StringType)),
     description = "List of the facet IDs to filter by (using AND)"
   )
+
+  val includeMeasurements: Argument[Option[Boolean]] = Argument(
+    "includeMeasurements",
+    OptionInputType(BooleanType),
+    description = "Whether to include measurements in the response"
+  )
 }

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -331,7 +331,7 @@ object Objects extends Logging {
           "Target-disease associations calculated on-the-fly using configurable data source weights and evidence filters. Returns associations with aggregated scores and evidence counts supporting the target-disease relationship."
         ),
         arguments =
-          BIds :: indirectTargetEvidences :: datasourceSettingsListArg :: facetFiltersListArg :: BFilterString :: scoreSorting :: pageArg :: Nil,
+          BIds :: indirectTargetEvidences :: datasourceSettingsListArg :: includeMeasurements :: facetFiltersListArg :: BFilterString :: scoreSorting :: pageArg :: Nil,
         complexity = Some(complexityCalculator(pageArg)),
         resolve = ctx => {
           (ctx arg datasourceSettingsListArg) foreach { settingsList =>
@@ -350,6 +350,7 @@ object Objects extends Logging {
             ctx.value,
             ctx arg datasourceSettingsListArg,
             ctx arg indirectTargetEvidences getOrElse false,
+            ctx arg includeMeasurements getOrElse false,
             ctx arg facetFiltersListArg getOrElse (Seq.empty),
             ctx arg BIds map (_.toSet) getOrElse Set.empty,
             ctx arg BFilterString,


### PR DESCRIPTION
as part of opentargets/issues#3947
- include/exclude measurement traits on AOTF target page
- implementation of this required an "is_measurement" to be added to the AOTF by target data (POS). The filtering concept is generic so any number of (column, value) pairs can by passed through. 