### PR TITLE
docs: clarify several responses and arguments

### DIFF
--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -198,7 +198,7 @@ object Arguments {
   val scoreSorting: Argument[Option[String]] = Argument(
     "orderByScore",
     OptionInputType(StringType),
-    description = "Ordering for the associations. It accepts a string with two words separated by a space. The first word is the column to sort by. This can be either by `score` for sorting by the overall association score (default), a datasource id (e.g. `impc`) or a datatype id (e.g. `animal_model`). The second word is the order: `desc` (default) or `asc`.",
+    description = "Ordering for the associations. Accepts a string with two words separated by a space. The first word is the column to sort by: either `score` to use the overall association score (default), a datasource id (e.g., `impc`), or a datatype id (e.g., `animal_model`). The second word is the order: `desc` (default) or `asc`.",
   )
 
   val AId: Argument[String] =

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -43,7 +43,7 @@ object Arguments {
       "Pagination settings for controlling result set size and page navigation. Uses zero-based indexing to specify which page of results to retrieve."
     ),
     DocumentInputField("index", "Zero-based page index"),
-    DocumentInputField("size", "Number of items per page")
+    DocumentInputField("size", "Number of items per page [Default: 25, Max: 3000]"),
   )
 
   val datasourceSettingsInputImp: InputObjectType[DatasourceSettings] =
@@ -81,7 +81,7 @@ object Arguments {
                                                          "Pagination settings with index and size"
   )
   val pageSize: Argument[Option[Int]] =
-    Argument("size", OptionInputType(IntType), description = "Number of items per page")
+    Argument("size", OptionInputType(IntType), description = "Number of items per page [Default: 25, Max: 3000]")
   val cursor: Argument[Option[String]] =
     Argument("cursor", OptionInputType(StringType), description = "Opaque cursor for pagination")
   val scoreThreshold: Argument[Option[Double]] = Argument(

--- a/app/models/gql/Arguments.scala
+++ b/app/models/gql/Arguments.scala
@@ -198,7 +198,7 @@ object Arguments {
   val scoreSorting: Argument[Option[String]] = Argument(
     "orderByScore",
     OptionInputType(StringType),
-    description = "Ordering for the associations. By default is score desc"
+    description = "Ordering for the associations. It accepts a string with two words separated by a space. The first word is the column to sort by. This can be either by `score` for sorting by the overall association score (default), a datasource id (e.g. `impc`) or a datatype id (e.g. `animal_model`). The second word is the order: `desc` (default) or `asc`.",
   )
 
   val AId: Argument[String] =

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1065,7 +1065,7 @@ object Objects extends Logging {
                     "Upper bin classification going from more constrained to less constrained"
       ),
       DocumentField("upperBin6",
-                    "Interpretable classification of constraint based on 6 bins. [Values: 0:very high`, 1: `high`, 2: `medium`, 3: `low`, 4: `very low`, 5: `very low`]"
+                    "Interpretable classification of constraint based on 6 bins. [Values: 0: `very high`, 1: `high`, 2: `medium`, 3: `low`, 4: `very low`, 5: `very low`]"
       ),
       DocumentField(
         "upperRank",

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -158,7 +158,7 @@ object Objects extends Logging {
     DocumentField("functionDescriptions",
                   "Functional descriptions of the target gene sourced from UniProt"
     ),
-    DocumentField("constraint", "Constraint scores for the target gene from GnomAD"),
+    DocumentField("constraint", "Constraint scores for the target gene from GnomAD based on loss-of-function intolerance."),
     DocumentField("genomicLocation", "Genomic location information of the target gene"),
     DocumentField("go", "List of Gene Ontology (GO) annotations related to the target"),
     DocumentField(
@@ -1065,7 +1065,7 @@ object Objects extends Logging {
                     "Upper bin classification going from more constrained to less constrained"
       ),
       DocumentField("upperBin6",
-                    "Upper bin6 classification going from more constrained to less constrained"
+                    "Interpretable classification of constraint based on 6 bins. [Values: 0:very high`, 1: `high`, 2: `medium`, 3: `low`, 4: `very low`, 5: `very low`]"
       ),
       DocumentField(
         "upperRank",

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -2148,7 +2148,7 @@ object Objects extends Logging {
   implicit val variantEffectImp: ObjectType[Backend, VariantEffect] =
     deriveObjectType[Backend, VariantEffect](
       ObjectTypeDescription("Predicted or measured effect of the variant based on various methods"),
-      DocumentField("method", "Method used to predict or measure the variant effect"),
+      DocumentField("method", "Method used to predict or measure the variant effect (e.g. VEP, SIFT, GERP, AlphaMissense, FoldX)"),
       DocumentField("assessment", "Assessment of the variant effect"),
       DocumentField("score", "Score indicating the severity or impact of the variant effect"),
       DocumentField("assessmentFlag", "Flag indicating the reliability of the assessment"),

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1065,7 +1065,7 @@ object Objects extends Logging {
                     "Upper bin classification going from more constrained to less constrained"
       ),
       DocumentField("upperBin6",
-                    "Interpretable classification of constraint based on 6 bins. [Values: 0: `very high`, 1: `high`, 2: `medium`, 3: `low`, 4: `very low`, 5: `very low`]"
+                    "Interpretable classification of constraint based on 6 bins. [GnomAD labels: 0: `very high`, 1: `high`, 2: `medium`, 3: `low`, 4: `very low`, 5: `very low`]"
       ),
       DocumentField(
         "upperRank",

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1428,7 +1428,7 @@ object Objects extends Logging {
         "Indication information linking a drug or clinical candidate molecule to a disease"
       ),
       DocumentField("maxPhaseForIndication",
-                    "Maximum clinical trial phase for this drug-disease indication"
+                    "Maximum clinical trial phase for this drug-disease indication. [Values: -1: `Unknown`, 0: `Phase 0`, 0.5: `Phase I (Early)`, 1: `Phase I`, 2: `Phase II`, 3: `Phase III`, 4: `Phase IV`]"
       ),
       DocumentField("references", "Reference information supporting the indication"),
       ReplaceField(
@@ -1572,7 +1572,7 @@ object Objects extends Logging {
     ),
     DocumentField(
       "maximumClinicalTrialPhase",
-      "Highest clinical trial phase reached by the drug or clinical candidate molecule"
+      "Highest clinical trial phase reached by the drug or clinical candidate molecule. [Values: -1: `Unknown`, 0: `Phase 0`, 0.5: `Phase I (Early)`, 1: `Phase I`, 2: `Phase II`, 3: `Phase III`, 4: `Phase IV`]"
     ),
     DocumentField("isApproved",
                   "Flag indicating whether the drug has received regulatory approval"
@@ -1892,7 +1892,7 @@ object Objects extends Logging {
     DocumentField("targetId", "Open Targets target identifier"),
     DocumentField("diseaseId", "Open Targets disease identifier"),
     DocumentField("drugId", "Open Targets molecule identifier"),
-    DocumentField("phase", "Clinical development stage of the drug"),
+    DocumentField("phase", "Clinical development stage of the drug. [Values: -1: `Unknown`, 0: `Phase 0`, 0.5: `Phase I (Early)`, 1: `Phase I`, 2: `Phase II`, 3: `Phase III`, 4: `Phase IV`]"),
     DocumentField("mechanismOfAction", "Drug pharmacological action"),
     DocumentField("status", "Clinical trial status for the drug/indication pair"),
     DocumentField("targetClass",
@@ -2726,7 +2726,7 @@ object Objects extends Logging {
     DocumentField("log2FoldChangeValue", "Log2 fold expression change in contrast experiment"),
     DocumentField("biologicalModelAllelicComposition", "Allelic composition of the model organism"),
     DocumentField("confidence", "Confidence qualifier on the reported evidence"),
-    DocumentField("clinicalPhase", "Phase of the clinical trial"),
+    DocumentField("clinicalPhase", "Phase of the clinical trial. [Values: -1: `Unknown`, 0: `Phase 0`, 0.5: `Phase I (Early)`, 1: `Phase I`, 2: `Phase II`, 3: `Phase III`, 4: `Phase IV`]"),
     DocumentField("clinicalStatus", "Current stage of a clinical study"),
     DocumentField("clinicalSignificances", "Standard terms to define clinical significance"),
     DocumentField("resourceScore",


### PR DESCRIPTION
- Clarify pagination docs with default and max page size; align argument descriptions.
- Explain association score sorting format (column + order) and accepted values.
- Enrich constraint, clinical phase, and variant effect method documentation across molecules/indications/evidence.

I haven't tested the API builds normally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines GraphQL argument and field documentation: adds pagination defaults/limits, clarifies association sorting syntax, and enriches constraint, clinical phase, and variant effect method descriptions.
> 
> - **GraphQL Arguments (`app/models/gql/Arguments.scala`)**:
>   - `page.size` and `size` argument: specify default (25) and max (3000).
>   - `orderByScore`: describe sortable columns (overall `score`, datasource id, datatype id) and order (`asc`/`desc`).
> - **GraphQL Objects (`app/models/gql/Objects.scala`)**:
>   - Target `constraint` and `Constraint.upperBin6`: expanded explanations (LoF intolerance; 6-bin labels).
>   - Clinical phase fields: add value mapping for `IndicationRow.maxPhaseForIndication`, `Drug.maximumClinicalTrialPhase`, `KnownDrug.phase`, and `Evidence.clinicalPhase`.
>   - `VariantEffect.method`: include example methods (VEP, SIFT, GERP, AlphaMissense, FoldX).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4807fa4df92700a4db8b1224446b9778bcb7e822. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->