### PR TITLE
Add "-Wunused:imports"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "io.opentargets"
 
 version := "latest"
 
-scalacOptions ++= Seq("-feature", "-explain")
+scalacOptions ++= Seq("-feature", "-explain", "-Wunused:imports")
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayLogback)
 


### PR DESCRIPTION
This flag caused the IDE to show warnings for unused imports.
vscode does not provide this warning out of the box. Therefore it would be very useful to add.
