### PR TITLE
feat(drug): expose synonyms/tradeNames as {label, source}

### DIFF
--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -1,17 +1,18 @@
 package models.entities
 
-import models.entities.Target.labelAndSourceImpF
 import play.api.libs.json._
 import slick.jdbc.GetResult
 import utils.db.DbJsonParser.fromPositionedResult
 
 case class DrugReferences(source: String, ids: Seq[String])
 
+case class DrugLabelAndSource(label: String, source: String)
+
 case class Drug(
     id: String,
     name: String,
-    synonyms: Seq[LabelAndSource],
-    tradeNames: Seq[LabelAndSource],
+    synonyms: Seq[DrugLabelAndSource],
+    tradeNames: Seq[DrugLabelAndSource],
     childChemblIds: Option[Seq[String]], // Gone?
     drugType: String,
     crossReferences: Option[Seq[DrugReferences]],
@@ -24,6 +25,7 @@ case class Drug(
 object Drug {
   implicit val getResult: GetResult[Drug] = GetResult(fromPositionedResult[Drug])
   implicit val DrugXRefImpW: OFormat[DrugReferences] = Json.format[DrugReferences]
+  implicit val drugLabelAndSourceImpF: OFormat[DrugLabelAndSource] = Json.format[DrugLabelAndSource]
   implicit val drugImplicitR: Reads[Drug] = Json.reads[Drug]
   implicit val drugImplicitW: OWrites[Drug] = Json.writes[Drug]
 }

--- a/app/models/entities/Drug.scala
+++ b/app/models/entities/Drug.scala
@@ -1,5 +1,6 @@
 package models.entities
 
+import models.entities.Target.labelAndSourceImpF
 import play.api.libs.json._
 import slick.jdbc.GetResult
 import utils.db.DbJsonParser.fromPositionedResult
@@ -9,8 +10,8 @@ case class DrugReferences(source: String, ids: Seq[String])
 case class Drug(
     id: String,
     name: String,
-    synonyms: Seq[String],
-    tradeNames: Seq[String],
+    synonyms: Seq[LabelAndSource],
+    tradeNames: Seq[LabelAndSource],
     childChemblIds: Option[Seq[String]], // Gone?
     drugType: String,
     crossReferences: Option[Seq[DrugReferences]],

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1646,6 +1646,13 @@ object Objects extends OTLogging {
       DocumentField("year", "Year when the warning was issued")
     )
 
+  implicit val drugLabelAndSourceImp: ObjectType[Backend, DrugLabelAndSource] =
+    deriveObjectType[Backend, DrugLabelAndSource](
+      ObjectTypeDescription("Label with source information"),
+      DocumentField("label", "Label value (e.g., synonym, symbol)"),
+      DocumentField("source", "Source database of the label")
+    )
+
   implicit lazy val drugImp: ObjectType[Backend, Drug] = deriveObjectType[Backend, Drug](
     ObjectTypeDescription(
       "Core annotation for drug or clinical candidate molecules. A drug in the platform is understood as any bioactive molecule with drug-like properties included in the EMBL-EBI ChEMBL database. All ChEMBL molecules fullfilling any of the next criteria are included in the database: a) Molecules with a known indication. b) Molecules with a known mechanism of action c) ChEMBL molecules included in the DrugBank database d) Molecules that are acknowledged as chemical probes"

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1652,8 +1652,14 @@ object Objects extends OTLogging {
     ),
     DocumentField("id", "Drug or clinical candidate molecule identifier"),
     DocumentField("name", "Generic name of the drug molecule"),
-    DocumentField("synonyms", "List of alternative names for the drug"),
-    DocumentField("tradeNames", "List of brand names for the drug"),
+    DocumentField(
+      "synonyms",
+      "List of alternative names for the drug, each with its source (e.g. ChEMBL, or AACT for names mined from clinical trials)"
+    ),
+    DocumentField(
+      "tradeNames",
+      "List of brand names for the drug, each with its source"
+    ),
     DocumentField(
       "drugType",
       "Classification of the molecule's therapeutic category or chemical class (e.g. Antibody)"


### PR DESCRIPTION
## Summary

Propagate the `drug_molecule` schema change into the API. `synonyms` and `tradeNames` changed from `array<string>` to `array<struct<label, source>>` (opentargets/pts#142, tracking issue opentargets/issues#4414), and the POS ClickHouse `drug` table now stores `Array(Tuple(label String, source String))` (opentargets/platform-output-support#130). The API must read and expose the new shape.

## What changed

- **`app/models/entities/Drug.scala`** — `synonyms`/`tradeNames`: `Seq[String]` → `Seq[LabelAndSource]` (the existing type `Target` already uses), plus an import for its JSON `OFormat`. The ClickHouse read path (`fromPositionedResult`) parses each row as JSON via `Reads[Drug]`; ClickHouse emits a named `Tuple(label, source)` as a `{label, source}` object, exactly how `crossReferences` (`Tuple(source, ids)`) already deserializes.
- **`app/models/gql/Objects.scala`** — the `Drug` GraphQL type is `deriveObjectType`, so the `synonyms`/`tradeNames` field type **auto-updates** to `[LabelAndSource]` (which already has a documented `ObjectType` exposing `label`/`source`). The two `DocumentField` descriptions are updated to describe the provenance — mirroring the schema documentation added in ot_croissant (opentargets/ot_croissant#47):
  - `synonyms` → "List of alternative names for the drug, each with its source (e.g. ChEMBL, or AACT for names mined from clinical trials)"
  - `tradeNames` → "List of brand names for the drug, each with its source"

No resolver, search, or other code references drug `synonyms`/`tradeNames` as strings (verified), so this is the whole change.

## GraphQL impact

`synonyms`/`tradeNames` change from `[String]` to `[LabelAndSource]` (`{ label source }`). This is a **breaking change for clients** that select these as scalars — consumers must now request the subfields. It matches how `Target.synonyms` is already exposed, and lands with the new data in the 26.06 run.

## Note

Based on `master`. I could not run `sbt compile` locally (this environment only has Java 17; the project targets Java 21 via sdkman) — the change is a direct reuse of the established `LabelAndSource` pattern, so CI compilation is the verification.
