### PR TITLE
added strand enum but maintained integer repr in graphql

### DIFF
--- a/app/models/entities/Target.scala
+++ b/app/models/entities/Target.scala
@@ -8,12 +8,17 @@ import slick.jdbc.GetResult
 import utils.OTLogging
 import utils.db.DbJsonParser.fromPositionedResult
 
+enum Strand(val value: Int):
+  case Positive extends Strand(1)
+  case Negative extends Strand(-1)
+  case Unknown extends Strand(0)
+
 case class CanonicalTranscript(
     id: String,
     chromosome: String,
     start: Long,
     end: Long,
-    strand: String
+    strand: Strand
 )
 
 case class ChemicalProbeUrl(niceName: String, url: Option[String])
@@ -91,7 +96,7 @@ case class Homologue(
     isHighConfidence: Option[String]
 )
 
-case class GenomicLocation(chromosome: String, start: Long, end: Long, strand: Int)
+case class GenomicLocation(chromosome: String, start: Long, end: Long, strand: Strand)
 
 case class GeneOntology(
     id: String,
@@ -174,6 +179,16 @@ object Target extends OTLogging {
 
   implicit val getTargetFromDB: GetResult[Target] =
     GetResult(fromPositionedResult[Target])
+
+  implicit val strandWrites: Writes[Strand] = Writes(s => JsNumber(s.value))
+  implicit val strandReads: Reads[Strand] = Reads {
+    case JsNumber(n) =>
+      Strand.values.find(_.value == n.toIntExact) match {
+        case Some(v) => JsSuccess(v)
+        case None    => JsError(s"Invalid Strand value: $n")
+      }
+    case _ => JsError("Strand must be a number")
+  }
 
   implicit val tepImpW: OWrites[Tep] = Json.writes[Tep]
   implicit val tepImpR: Reads[Tep] =

--- a/app/models/gql/Objects.scala
+++ b/app/models/gql/Objects.scala
@@ -1130,13 +1130,30 @@ object Objects extends OTLogging {
       DocumentField("label", "Label value (e.g., synonym, symbol)"),
       DocumentField("source", "Source database of the label")
     )
+  implicit val StrandEnumType: EnumType[Strand] = EnumType(
+    "Strand",
+    Some("Strand orientation of a genomic feature"),
+    List(
+      EnumValue("POSITIVE", value = Strand.Positive, description = Some("Positive strand")),
+      EnumValue("NEGATIVE", value = Strand.Negative, description = Some("Negative strand")),
+      EnumValue("UNKNOWN", value = Strand.Unknown, description = Some("Unknown strand"))
+    )
+  )
   implicit val genomicLocationImp: ObjectType[Backend, GenomicLocation] =
     deriveObjectType[Backend, GenomicLocation](
       ObjectTypeDescription("Genomic location information of the target gene"),
       DocumentField("chromosome", "Chromosome on which the target is located"),
       DocumentField("start", "Genomic start position of the target gene"),
       DocumentField("end", "Genomic end position of the target gene"),
-      DocumentField("strand", "Strand orientation of the target gene")
+      ReplaceField(
+        "strand",
+        Field(
+          "strand",
+          IntType,
+          Some("Strand orientation of the target gene (1 = positive, -1 = negative, 0 = unknown)"),
+          resolve = _.value.strand.value
+        )
+      )
     )
   implicit val targetClassImp: ObjectType[Backend, TargetClass] =
     deriveObjectType[Backend, TargetClass](
@@ -1158,8 +1175,18 @@ object Objects extends OTLogging {
       DocumentField("chromosome", "Chromosome location of the canonical transcript"),
       DocumentField("start", "Genomic start position of the canonical transcript"),
       DocumentField("end", "Genomic end position of the canonical transcript"),
-      DocumentField("strand", "Strand orientation of the canonical transcript")
+      DocumentField("strand", "Strand orientation of the canonical transcript"),
+      ReplaceField(
+        "strand",
+        Field(
+          "strand",
+          IntType,
+          Some("Strand orientation of the target gene (1 = positive, -1 = negative, 0 = unknown)"),
+          resolve = _.value.strand.value
+        )
+      )
     )
+
   implicit val constraintImp: ObjectType[Backend, Constraint] =
     deriveObjectType[Backend, Constraint](
       ObjectTypeDescription(


### PR DESCRIPTION
- part of opentargets/issues#4524
- unify "strand" in an enum, used by canonicalTranscript and genomicLocation. 
- display will be an int (1 or -1) but we could go with the enum label if that's neater