### PR TITLE
update clickhouse jdbc

### DIFF
--- a/app/models/ClickhouseRetriever.scala
+++ b/app/models/ClickhouseRetriever.scala
@@ -8,7 +8,7 @@ import models.entities.*
 import net.logstash.logback.argument.StructuredArguments.keyValue
 import services.ApplicationStart
 import slick.basic.DatabaseConfig
-import slick.jdbc.{GetResult, SQLActionBuilder}
+import slick.jdbc.{GetResult, PositionedResult, SQLActionBuilder}
 import utils.OTLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -59,17 +59,33 @@ class ClickhouseRetriever(config: OTSettings)(implicit
     }
   }
 
+  // clickhouse-jdbc's PreparedStatement (what Slick's sql"..." normally executes through) ignores
+  // the trailing FORMAT JSONEachRow clause and returns typed per-column results instead of the
+  // single JSON-blob column DbJsonParser/GetResult expect; a plain Statement respects it. So this
+  // runs the raw statement directly instead of going through Slick's default PreparedStatement path.
   def executeQuery[A, B <: Q](q: B)(implicit rconv: GetResult[A]): Future[Vector[A]] = {
     logger.debug(s"execute query from esecuele Q ${q.toString}")
-    val qq = q.as[A]
+    val qStr = q.rep
 
     appStart.DatabaseCallCounter.labelValues(db_name, "executeQuery").inc()
 
-    db.run(qq.asTry).map {
+    val action = SimpleDBIO[Vector[A]] { ctx =>
+      val st = ctx.connection.createStatement()
+      try {
+        val rs = st.executeQuery(qStr)
+        try {
+          val pr = new PositionedResult(rs) { def close(): Unit = () }
+          val b = Vector.newBuilder[A]
+          while (pr.nextRow) b += rconv(pr)
+          b.result()
+        } finally rs.close()
+      } finally st.close()
+    }
+
+    db.run(action.asTry).map {
       case Success(v) => v
       case Failure(ex) =>
-        lazy val qStr = qq.statements.mkString("\n")
-        logger.error(s"executeQuery an exception was thrown ${ex.getMessage} with Query $qStr", ex)
+        logger.error(s"executeQuery an exception was thrown ${ex.getCause()} with Query $qStr", ex)
         Vector.empty // TODO: maybe we should return the error instead of an empty vector, to inform the user
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ libraryDependencies += "org.playframework" %% "play-slick" % "6.2.0"
 libraryDependencies += "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
 
 val sangriaVersion = "4.2.10"
-libraryDependencies += "com.clickhouse" % "clickhouse-jdbc" % "0.7.2"
+libraryDependencies += "com.clickhouse" % "clickhouse-jdbc" % "0.10.0"
 libraryDependencies += "org.apache.httpcomponents.client5" % "httpclient5" % "5.5"
 libraryDependencies += "org.sangria-graphql" %% "sangria" % sangriaVersion
 libraryDependencies += "org.sangria-graphql" %% "sangria-play-json-play30" % "2.0.3"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -11,11 +11,13 @@ slick.dbs {
       driver = "com.clickhouse.jdbc.ClickHouseDriver"
       url = "jdbc:clickhouse://127.0.0.1:8123"
       url = ${?SLICK_CLICKHOUSE_URL}
+      url = ${slick.dbs.default.db.url}"?clickhouse.jdbc.v1=true"
       numThreads = 32
       maxConnections = 32
       minConnections = 4
       queueSize = 4096
       connectionTimeout = 10000
+      compress = 0
     }
   }
 }
@@ -288,7 +290,7 @@ ot {
     name = "Open Targets GraphQL & REST API Beta"
     apiVersion = "25.2.0"
     apiVersion = ${?META_API_VERSION}
-    dataRelease = "26.03"
+    dataRelease = "26.09"
     dataRelease = ${?META_DATA_RELEASE}
     product = "platform"
     product = ${?META_PRODUCT_NAME}


### PR DESCRIPTION
we bumped the clickhouse server version to 26.8 which means we have to bump the clickhouse jdbc. This had a few consequences on the way we pass the query through.